### PR TITLE
Revise README and add terminal to register-function command

### DIFF
--- a/emulator/README.md
+++ b/emulator/README.md
@@ -51,7 +51,7 @@ Run `./gradlew build` to compile the contract.
 
 `register` command will register the specified contract with the specified contract id and binary name.
 
- For example, the contract `com.scalar.client.tool.emulator.contract.StateUpdater.java` with id `state-updater-contract` can be registered as follows.
+ For example, the contract `com.scalar.client.tool.emulator.contract.StateUpdater` with id `state-updater-contract` can be registered as follows.
 
 ```
 scalar> register state-updater-contract com.scalar.client.tool.emulator.contract.StateUpdater ./build/classes/java/main/com/scalar/client/tool/emulator/contract/StateUpdater.class
@@ -75,7 +75,7 @@ UDF is a business logic to update the mutable database in the Scalar DL network.
 For example, the UDF `com.scalar.client.tool.emulator.function.StateUpdater` with id `state-updater-function` can be registered as follows.
 
 ```
-scalar> register-function state-updater-function com.scalar.client.tool.emulator.function.StateUpdater.java ./build/classes/java/main/com/scalar/client/tool/emulator/function/StateUpdater.class
+scalar> register-function state-updater-function com.scalar.client.tool.emulator.function.StateUpdater ./build/classes/java/main/com/scalar/client/tool/emulator/function/StateUpdater.class
 ```
 
 ## Execute a UDF
@@ -85,7 +85,7 @@ Registered UDFs can only be executed with a registered contract, and the user ca
 For example, a UDF with id `state-updater-function` can be executed by a contract with id `state-updater-contract` as follows.
 
 ```
-scalar> execute state-updater-contract {"asset_id":"Y","_functions_":["state-updater-function"]} -fa {"asset_id":"Y","state":1}
+scalar> execute state-updater-contract {"asset_id":"Y","state":1,"_functions_":["state-updater-function"]} -fa {"asset_id":"Y","state":1}
 ```
 
 NOTE:

--- a/emulator/src/main/java/com/scalar/client/tool/emulator/command/RegisterFunction.java
+++ b/emulator/src/main/java/com/scalar/client/tool/emulator/command/RegisterFunction.java
@@ -59,9 +59,12 @@ public class RegisterFunction implements Runnable {
 
   private UdfManager udfManager;
 
+  private TerminalWrapper terminal;
+
   @Inject
-  public RegisterFunction(UdfManager udfManager) {
+  public RegisterFunction(TerminalWrapper terminal, UdfManager udfManager) {
     this.udfManager = udfManager;
+    this.terminal = terminal;
   }
 
   @Override
@@ -74,6 +77,7 @@ public class RegisterFunction implements Runnable {
       byte[] bytes = Files.readAllBytes(udfFile.toPath());
       long registeredAt = System.currentTimeMillis();
       udfManager.register(new UdfEntry(id, name, bytes, registeredAt));
+      terminal.println("UDF '" + id + "' successfully registered");
     } catch (IOException e) {
       throw new RegistryIOException("could not register udf " + id);
     }

--- a/emulator/src/test/java/com/scalar/client/tool/emulator/command/RegisterFunctionTest.java
+++ b/emulator/src/test/java/com/scalar/client/tool/emulator/command/RegisterFunctionTest.java
@@ -23,6 +23,7 @@ package com.scalar.client.tool.emulator.command;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
+import com.scalar.client.tool.emulator.TerminalWrapper;
 import com.scalar.ledger.udf.UdfEntry;
 import com.scalar.ledger.udf.UdfManager;
 import java.io.File;
@@ -40,13 +41,14 @@ import picocli.CommandLine;
 public class RegisterFunctionTest {
   @Mock UdfManager manager;
   @Mock File udfFile;
+  @Mock TerminalWrapper terminal;
   RegisterFunction registerFunction;
   File udf;
 
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
-    registerFunction = new RegisterFunction(manager);
+    registerFunction = new RegisterFunction(terminal, manager);
     udf = File.createTempFile("udf", ".class");
   }
 


### PR DESCRIPTION
This PR revises:
- Typo in UDF registration explanation.
- A missing required argument of executing the contract.
in README.md,

and also add the terminal to `register-function` command to display messages when UDF are successfully registered.