### PR TITLE
Move README.md to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,1 @@
-# Tools for Scalar DL
-
-This repository contains tools for use with Scalar DL.
-
-1. [Scalar DL Emulator](./emulator): for testing contracts on an in-memory ledger.
-2. [Scalar DL Explorer](./explorer): for viewing and validating assets on the ledger.
-
-Please see their respective folders for more information.
+docs/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Tools for Scalar DL
+
+This repository contains tools for use with Scalar DL.
+
+1. [Scalar DL Emulator](./emulator): for testing contracts on an in-memory ledger.
+2. [Scalar DL Explorer](./explorer): for viewing and validating assets on the ledger.
+
+Please see their respective folders for more information.


### PR DESCRIPTION
This PR moves README.md to the docs folder and creates a symbolic link in the root folder.