### PR TITLE
Fix URLs in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This repository contains tools for use with Scalar DL.
 
-1. [Scalar DL Emulator](./emulator): for testing contracts on an in-memory ledger.
-2. [Scalar DL Explorer](./explorer): for viewing and validating assets on the ledger.
+1. [Scalar DL Emulator](/emulator): for testing contracts on an in-memory ledger.
+2. [Scalar DL Explorer](/explorer): for viewing and validating assets on the ledger.
 
 Please see their respective folders for more information.


### PR DESCRIPTION
This PR fixes the relative URLs that point to the tool folders in `docs/README.md`.