### PR TITLE
Refactor resumable scanner for modularity and configurability

### DIFF
--- a/coordinator-state-deleter/common/build.gradle
+++ b/coordinator-state-deleter/common/build.gradle
@@ -1,0 +1,38 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+
+plugins {
+    id 'java-library'
+    id 'net.ltgt.errorprone' version "${errorpronePluginVersion}"
+    id "com.github.spotbugs" version "${spotbugsPluginVersion}"
+}
+
+dependencies {
+    errorprone "com.google.errorprone:error_prone_core:${errorproneVersion}"
+    spotbugs "com.github.spotbugs:spotbugs:${spotbugsVersion}"
+    compileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugsVersion}"
+    testCompileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugsVersion}"
+}
+
+spotless {
+    java {
+        target 'src/*/java/**/*.java'
+        importOrder()
+        removeUnusedImports()
+        googleJavaFormat(googleJavaFormatVersion)
+    }
+}
+
+spotbugs {
+    ignoreFailures = false
+    showStackTraces = true
+    showProgress = true
+    effort = Effort.valueOf('DEFAULT')
+    reportLevel = Confidence.valueOf('DEFAULT')
+    maxHeapSize = '1g'
+    extraArgs = ['-nested:false']
+    jvmArgs = ['-Duser.language=en']
+}
+
+spotbugsMain { reports.create('html') { required = true } }
+spotbugsTest { reports.create('html') { required = true } }

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
@@ -1,6 +1,5 @@
 package com.scalar.dl.tools.common;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,12 +20,14 @@ public final class FileUtils {
    * @param target the path to write to
    * @param content the bytes to write
    * @throws IOException if the write or rename fails
+   * @throws IllegalArgumentException if the target path has no file name
    */
-  @SuppressFBWarnings(
-      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-      justification = "target.getFileName() is never null for our use cases (non-root paths)")
   public static void writeAtomic(Path target, byte[] content) throws IOException {
-    Path tmp = target.resolveSibling(target.getFileName().toString() + ".tmp");
+    Path fileName = target.getFileName();
+    if (fileName == null) {
+      throw new IllegalArgumentException("The target path must have a file name");
+    }
+    Path tmp = target.resolveSibling(fileName.toString() + ".tmp");
     try {
       Files.write(tmp, content);
       Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
@@ -1,0 +1,42 @@
+package com.scalar.dl.tools.common;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/** Shared file-system utilities for I/O operations. */
+public final class FileUtils {
+
+  private FileUtils() {}
+
+  /**
+   * Atomically writes content to the target path via write-temp-and-rename.
+   *
+   * <p>Writes to a temporary sibling file ({@code <target>.tmp}) first, then renames it to the
+   * target path. This ensures that the target file is never left in a partially-written state, even
+   * if the process crashes mid-write. The temporary file is cleaned up on failure.
+   *
+   * @param target the path to write to
+   * @param content the bytes to write
+   * @throws IOException if the write or rename fails
+   */
+  @SuppressFBWarnings(
+      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+      justification = "target.getFileName() is never null for our use cases (non-root paths)")
+  public static void writeAtomic(Path target, byte[] content) throws IOException {
+    Path tmp = target.resolveSibling(target.getFileName().toString() + ".tmp");
+    try {
+      Files.write(tmp, content);
+      Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      try {
+        Files.deleteIfExists(tmp);
+      } catch (IOException suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
+    }
+  }
+}

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/FileUtilsTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/FileUtilsTest.java
@@ -1,0 +1,66 @@
+package com.scalar.dl.tools.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileUtilsTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void writeAtomic_nonExistentFileGiven_shouldCreateNewFile() throws IOException {
+    // Arrange
+    Path target = tempDir.resolve("test.json");
+    byte[] content = "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+
+    // Act
+    FileUtils.writeAtomic(target, content);
+
+    // Assert
+    assertThat(target).exists();
+    assertThat(Files.readAllBytes(target)).isEqualTo(content);
+  }
+
+  @Test
+  void writeAtomic_existentFileGiven_shouldOverwriteExistingFile() throws IOException {
+    // Arrange
+    Path target = tempDir.resolve("test.json");
+    Files.write(target, "old".getBytes(StandardCharsets.UTF_8));
+    byte[] newContent = "new".getBytes(StandardCharsets.UTF_8);
+
+    // Act
+    FileUtils.writeAtomic(target, newContent);
+
+    // Assert
+    assertThat(Files.readAllBytes(target)).isEqualTo(newContent);
+  }
+
+  @Test
+  void writeAtomic_shouldNotLeaveTmpFile() throws IOException {
+    // Arrange
+    Path target = tempDir.resolve("test.json");
+
+    // Act
+    FileUtils.writeAtomic(target, "data".getBytes(StandardCharsets.UTF_8));
+
+    // Assert
+    assertThat(tempDir.resolve("test.json.tmp")).doesNotExist();
+  }
+
+  @Test
+  void writeAtomic_fileWithNonExistentParentGiven_shouldThrowIOException() {
+    // Arrange
+    Path target = tempDir.resolve("no-such-dir").resolve("test.json");
+
+    // Act & Assert
+    assertThatThrownBy(() -> FileUtils.writeAtomic(target, "data".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(IOException.class);
+  }
+}

--- a/coordinator-state-deleter/resumable-scan/build.gradle
+++ b/coordinator-state-deleter/resumable-scan/build.gradle
@@ -20,6 +20,7 @@ configurations {
 }
 
 dependencies {
+    implementation project(':common')
     implementation "com.azure:azure-cosmos:${azureCosmosVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation "com.scalar-labs:scalardb:${scalarDbVersion}"

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
@@ -1,0 +1,32 @@
+package com.scalar.dl.tools.scan;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.cosmos.CosmosConfig;
+import com.scalar.dl.tools.scan.cosmos.CosmosResumableScanner;
+import java.nio.file.Path;
+
+/** Factory for creating {@link ResumableScanner} instances based on the configured storage. */
+public final class ResumableScannerFactory {
+
+  private final DatabaseConfig databaseConfig;
+
+  public ResumableScannerFactory(DatabaseConfig databaseConfig) {
+    this.databaseConfig = databaseConfig;
+  }
+
+  /**
+   * Creates a new {@link ResumableScanner} for the given checkpoint directory.
+   *
+   * @param checkpointDir directory for scan checkpoint state
+   * @return a new scanner
+   * @throws IllegalStateException if the configured storage is not supported
+   */
+  public ResumableScanner create(Path checkpointDir) {
+    String storage = databaseConfig.getStorage();
+    if (storage.equals(CosmosConfig.STORAGE_NAME)) {
+      return new CosmosResumableScanner(databaseConfig, checkpointDir);
+    }
+    throw new IllegalStateException(
+        "This tool only supports Cosmos DB. Configured storage: " + storage);
+  }
+}

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
@@ -19,14 +19,14 @@ public final class ResumableScannerFactory {
    *
    * @param checkpointDir directory for scan checkpoint state
    * @return a new scanner
-   * @throws IllegalStateException if the configured storage is not supported
+   * @throws IllegalArgumentException if the configured storage is not supported
    */
   public ResumableScanner create(Path checkpointDir) {
     String storage = databaseConfig.getStorage();
     if (CosmosConfig.STORAGE_NAME.equals(storage)) {
       return new CosmosResumableScanner(databaseConfig, checkpointDir);
     }
-    throw new IllegalStateException(
+    throw new IllegalArgumentException(
         "This tool only supports Cosmos DB. Configured storage: " + storage);
   }
 }

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScannerFactory.java
@@ -23,7 +23,7 @@ public final class ResumableScannerFactory {
    */
   public ResumableScanner create(Path checkpointDir) {
     String storage = databaseConfig.getStorage();
-    if (storage.equals(CosmosConfig.STORAGE_NAME)) {
+    if (CosmosConfig.STORAGE_NAME.equals(storage)) {
       return new CosmosResumableScanner(databaseConfig, checkpointDir);
     }
     throw new IllegalStateException(

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CheckpointManager.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CheckpointManager.java
@@ -1,14 +1,13 @@
 package com.scalar.dl.tools.scan.cosmos;
 
+import com.scalar.dl.tools.common.FileUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import javax.annotation.Nullable;
 
@@ -32,24 +31,6 @@ class CheckpointManager {
     this.checkpointDir = checkpointDir;
   }
 
-  @SuppressFBWarnings(
-      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-      justification = "target.getFileName() is never null for our use cases (non-root paths)")
-  private static void writeAtomic(Path target, byte[] content) throws IOException {
-    Path tmp = target.resolveSibling(target.getFileName().toString() + ".tmp");
-    try {
-      Files.write(tmp, content);
-      Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-    } catch (IOException e) {
-      try {
-        Files.deleteIfExists(tmp);
-      } catch (IOException suppressed) {
-        e.addSuppressed(suppressed);
-      }
-      throw e;
-    }
-  }
-
   /** Load continuation token for a given table and range, or null. */
   @Nullable
   public String loadContinuationToken(String tableName, String rangeId) {
@@ -69,7 +50,7 @@ class CheckpointManager {
   public void persistContinuationToken(String tableName, String rangeId, String token) {
     Path tokenPath = checkpointDir.resolve(tableName).resolve(rangeId + ".token");
     try {
-      writeAtomic(tokenPath, token.getBytes(StandardCharsets.UTF_8));
+      FileUtils.writeAtomic(tokenPath, token.getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(
           "Failed to persist continuation token for " + tableName + "/" + rangeId, e);
@@ -94,7 +75,7 @@ class CheckpointManager {
   public void persistFeedRanges(String tableName, String feedRangesJson) {
     Path feedRangesPath = checkpointDir.resolve(tableName).resolve(FEED_RANGES_FILE);
     try {
-      writeAtomic(feedRangesPath, feedRangesJson.getBytes(StandardCharsets.UTF_8));
+      FileUtils.writeAtomic(feedRangesPath, feedRangesJson.getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException("Failed to persist feed ranges for " + tableName, e);
     }

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
@@ -45,8 +45,7 @@ public final class CosmosResumableScanner implements ResumableScanner {
 
   private static final Logger logger = LoggerFactory.getLogger(CosmosResumableScanner.class);
   private static final ObjectMapper mapper = new ObjectMapper();
-  private static final int DEFAULT_MAX_WORKER_THREADS = 32;
-  private static final int DEFAULT_MAX_ITEM_COUNT = 100;
+  private static final int SHUTDOWN_TIMEOUT_SECONDS = 30;
 
   private final CosmosClient cosmosClient;
   private final CheckpointManager checkpointManager;
@@ -56,15 +55,11 @@ public final class CosmosResumableScanner implements ResumableScanner {
   private ExecutorService scanExecutor;
 
   public CosmosResumableScanner(DatabaseConfig databaseConfig, Path checkpointDir) {
-    this(databaseConfig, checkpointDir, DEFAULT_MAX_WORKER_THREADS, DEFAULT_MAX_ITEM_COUNT);
-  }
-
-  public CosmosResumableScanner(
-      DatabaseConfig databaseConfig, Path checkpointDir, int maxWorkerThreads, int maxItemCount) {
+    CosmosResumableScannerConfig config = new CosmosResumableScannerConfig(databaseConfig);
     cosmosClient = CosmosUtils.buildCosmosClient(new CosmosConfig(databaseConfig));
     this.checkpointManager = new CheckpointManager(checkpointDir);
-    this.maxWorkerThreads = maxWorkerThreads;
-    this.maxItemCount = maxItemCount;
+    this.maxWorkerThreads = config.getMaxWorkerThreads();
+    this.maxItemCount = config.getMaxItemCount();
 
     try {
       this.storageAdmin = StorageFactory.create(databaseConfig.getProperties()).getStorageAdmin();
@@ -72,19 +67,6 @@ public final class CosmosResumableScanner implements ResumableScanner {
       cosmosClient.close();
       throw new RuntimeException("Failed to create DistributedStorageAdmin", e);
     }
-  }
-
-  @VisibleForTesting
-  CosmosResumableScanner(
-      CosmosClient cosmosClient,
-      CheckpointManager checkpointManager,
-      DistributedStorageAdmin storageAdmin) {
-    this(
-        cosmosClient,
-        checkpointManager,
-        storageAdmin,
-        DEFAULT_MAX_WORKER_THREADS,
-        DEFAULT_MAX_ITEM_COUNT);
   }
 
   @VisibleForTesting
@@ -109,8 +91,8 @@ public final class CosmosResumableScanner implements ResumableScanner {
     try {
       // 30 seconds is a conservative upper bound to allow in-flight Cosmos DB HTTP requests to
       // complete or time out after interruption.
-      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
-        logger.warn("Scan executor did not terminate within 30 seconds");
+      if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        logger.warn("Scan executor did not terminate within {} seconds", SHUTDOWN_TIMEOUT_SECONDS);
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
@@ -1,0 +1,37 @@
+package com.scalar.dl.tools.scan.cosmos;
+
+import com.scalar.db.config.DatabaseConfig;
+
+/** Configuration for {@link CosmosResumableScanner}, extending ScalarDB properties. */
+public final class CosmosResumableScannerConfig {
+
+  static final String PROP_MAX_SCAN_THREADS = "scalar.dl.tools.scan.max_threads";
+  static final String PROP_SCAN_PAGE_SIZE = "scalar.dl.tools.scan.page_size";
+  private static final int DEFAULT_MAX_WORKER_THREADS = 32;
+  private static final int DEFAULT_MAX_ITEM_COUNT = 100;
+
+  private final int maxWorkerThreads;
+  private final int maxItemCount;
+
+  public CosmosResumableScannerConfig(DatabaseConfig databaseConfig) {
+    this.maxWorkerThreads =
+        getIntProperty(databaseConfig, PROP_MAX_SCAN_THREADS, DEFAULT_MAX_WORKER_THREADS);
+    this.maxItemCount = getIntProperty(databaseConfig, PROP_SCAN_PAGE_SIZE, DEFAULT_MAX_ITEM_COUNT);
+  }
+
+  private static int getIntProperty(DatabaseConfig config, String key, int defaultValue) {
+    String value = config.getProperties().getProperty(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    return Integer.parseInt(value);
+  }
+
+  public int getMaxWorkerThreads() {
+    return maxWorkerThreads;
+  }
+
+  public int getMaxItemCount() {
+    return maxItemCount;
+  }
+}

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
@@ -15,16 +15,28 @@ public final class CosmosResumableScannerConfig {
 
   public CosmosResumableScannerConfig(DatabaseConfig databaseConfig) {
     this.maxWorkerThreads =
-        getIntProperty(databaseConfig, PROP_MAX_SCAN_THREADS, DEFAULT_MAX_WORKER_THREADS);
-    this.maxItemCount = getIntProperty(databaseConfig, PROP_SCAN_PAGE_SIZE, DEFAULT_MAX_ITEM_COUNT);
+        getPositiveIntProperty(databaseConfig, PROP_MAX_SCAN_THREADS, DEFAULT_MAX_WORKER_THREADS);
+    this.maxItemCount =
+        getPositiveIntProperty(databaseConfig, PROP_SCAN_PAGE_SIZE, DEFAULT_MAX_ITEM_COUNT);
   }
 
-  private static int getIntProperty(DatabaseConfig config, String key, int defaultValue) {
+  private static int getPositiveIntProperty(DatabaseConfig config, String key, int defaultValue) {
     String value = config.getProperties().getProperty(key);
     if (value == null) {
       return defaultValue;
     }
-    return Integer.parseInt(value);
+    int parsed;
+    try {
+      parsed = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "The property '" + key + "' must be a valid integer: " + value, e);
+    }
+    if (parsed <= 0) {
+      throw new IllegalArgumentException(
+          "The property '" + key + "' must be a positive integer: " + value);
+    }
+    return parsed;
   }
 
   public int getMaxWorkerThreads() {

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfig.java
@@ -5,8 +5,8 @@ import com.scalar.db.config.DatabaseConfig;
 /** Configuration for {@link CosmosResumableScanner}, extending ScalarDB properties. */
 public final class CosmosResumableScannerConfig {
 
-  static final String PROP_MAX_SCAN_THREADS = "scalar.dl.tools.scan.max_threads";
-  static final String PROP_SCAN_PAGE_SIZE = "scalar.dl.tools.scan.page_size";
+  static final String PROP_MAX_SCAN_THREADS = "scalar.dl.tools.scan.cosmos.max_threads";
+  static final String PROP_SCAN_PAGE_SIZE = "scalar.dl.tools.scan.cosmos.page_size";
   private static final int DEFAULT_MAX_WORKER_THREADS = 32;
   private static final int DEFAULT_MAX_ITEM_COUNT = 100;
 

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfigTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfigTest.java
@@ -1,0 +1,61 @@
+package com.scalar.dl.tools.scan.cosmos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class CosmosResumableScannerConfigTest {
+
+  private static DatabaseConfig createConfig(Properties extra) {
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    props.setProperty(DatabaseConfig.CONTACT_POINTS, "https://localhost:8081");
+    props.setProperty(DatabaseConfig.PASSWORD, "dummy");
+    props.putAll(extra);
+    return new DatabaseConfig(props);
+  }
+
+  @Test
+  void constructor_noExtraPropertiesSet_shouldUseDefaults() {
+    // Arrange
+    DatabaseConfig databaseConfig = createConfig(new Properties());
+
+    // Act
+    CosmosResumableScannerConfig config = new CosmosResumableScannerConfig(databaseConfig);
+
+    // Assert
+    assertThat(config.getMaxWorkerThreads()).isEqualTo(32);
+    assertThat(config.getMaxItemCount()).isEqualTo(100);
+  }
+
+  @Test
+  void constructor_extraPropertiesSet_shouldUseCustomValues() {
+    // Arrange
+    Properties extra = new Properties();
+    extra.setProperty(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS, "16");
+    extra.setProperty(CosmosResumableScannerConfig.PROP_SCAN_PAGE_SIZE, "50");
+    DatabaseConfig databaseConfig = createConfig(extra);
+
+    // Act
+    CosmosResumableScannerConfig config = new CosmosResumableScannerConfig(databaseConfig);
+
+    // Assert
+    assertThat(config.getMaxWorkerThreads()).isEqualTo(16);
+    assertThat(config.getMaxItemCount()).isEqualTo(50);
+  }
+
+  @Test
+  void constructor_invalidIntegerValue_shouldThrowNumberFormatException() {
+    // Arrange
+    Properties extra = new Properties();
+    extra.setProperty(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS, "not-a-number");
+    DatabaseConfig databaseConfig = createConfig(extra);
+
+    // Act & Assert
+    assertThatThrownBy(() -> new CosmosResumableScannerConfig(databaseConfig))
+        .isInstanceOf(NumberFormatException.class);
+  }
+}

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfigTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerConfigTest.java
@@ -48,7 +48,7 @@ class CosmosResumableScannerConfigTest {
   }
 
   @Test
-  void constructor_invalidIntegerValue_shouldThrowNumberFormatException() {
+  void constructor_invalidIntegerValue_shouldThrowIllegalArgumentException() {
     // Arrange
     Properties extra = new Properties();
     extra.setProperty(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS, "not-a-number");
@@ -56,6 +56,33 @@ class CosmosResumableScannerConfigTest {
 
     // Act & Assert
     assertThatThrownBy(() -> new CosmosResumableScannerConfig(databaseConfig))
-        .isInstanceOf(NumberFormatException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS);
+  }
+
+  @Test
+  void constructor_zeroValue_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties extra = new Properties();
+    extra.setProperty(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS, "0");
+    DatabaseConfig databaseConfig = createConfig(extra);
+
+    // Act & Assert
+    assertThatThrownBy(() -> new CosmosResumableScannerConfig(databaseConfig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CosmosResumableScannerConfig.PROP_MAX_SCAN_THREADS);
+  }
+
+  @Test
+  void constructor_negativeValue_shouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties extra = new Properties();
+    extra.setProperty(CosmosResumableScannerConfig.PROP_SCAN_PAGE_SIZE, "-1");
+    DatabaseConfig databaseConfig = createConfig(extra);
+
+    // Act & Assert
+    assertThatThrownBy(() -> new CosmosResumableScannerConfig(databaseConfig))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CosmosResumableScannerConfig.PROP_SCAN_PAGE_SIZE);
   }
 }

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
@@ -67,7 +67,7 @@ class CosmosResumableScannerTest {
   }
 
   private CosmosResumableScanner createScanner() {
-    return new CosmosResumableScanner(cosmosClient, checkpointManager, storageAdmin);
+    return new CosmosResumableScanner(cosmosClient, checkpointManager, storageAdmin, 32, 100);
   }
 
   private FeedRange createMockFeedRange(String label) {

--- a/coordinator-state-deleter/settings.gradle
+++ b/coordinator-state-deleter/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'coordinator-state-deleter'
 
 include 'resumable-scan'
+include 'common'


### PR DESCRIPTION
## Description

This PR refactors the module to improve modularity and configurability.

Since the `writeAtomic` function will be used by future commands, it has been moved to a `common` module. This PR also introduces `ResumableScannerFactory` to allow other modules to create `ResumableScanner` instances without directly depending on storage-specific implementations.

## Related issues and/or PRs

- #37 

## Changes made

  - Extract the `writeAtomic()` into a new common module as a `FileUtils`
  - Add `ResumableScannerFactory` to create `ResumableScanner` instances based on the configured storage type
  - Add unit tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A