### PR TITLE
Refactor per-record scan handling into RecordHandler

### DIFF
--- a/coordinator-state-deleter/coordinator-state-cleanup/src/integration-test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorIntegrationTestBase.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/integration-test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorIntegrationTestBase.java
@@ -2,6 +2,9 @@ package com.scalar.dl.tools.cleanup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedTransactionAdmin;
@@ -288,8 +291,18 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
     String ledgerToken = createLedgerToken(DELETABLE_BEFORE_MS);
     String auditorToken = createAuditorToken(DELETABLE_BEFORE_MS);
 
-    RecordDeleter interruptingDeleter =
-        new InterruptingRecordDeleter(storage, Coordinator.NAMESPACE, 3);
+    // A spy that throws on the 3rd call, simulating a crash partway through the scan.
+    RecordDeleter interruptingDeleter = spy(new RecordDeleter(storage, Coordinator.NAMESPACE));
+    AtomicLong deleteCount = new AtomicLong();
+    doAnswer(
+            invocation -> {
+              if (deleteCount.incrementAndGet() >= 3) {
+                throw new RuntimeException("Simulated interruption");
+              }
+              return invocation.callRealMethod();
+            })
+        .when(interruptingDeleter)
+        .execute(any(Result.class));
 
     // Act 1: the first run fails partway through the scan.
     CoordinatorCleanupOrchestrator failingRun =
@@ -321,28 +334,5 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
     CoordinatorCleanupState finalState = stateManager.load();
     assertThat(finalState).isNotNull();
     assertThat(finalState.isCompleted()).isTrue();
-  }
-
-  /**
-   * A {@link RecordDeleter} that throws once it has been invoked {@code throwOnNthDelete} times,
-   * simulating a crash partway through the scan.
-   */
-  private static class InterruptingRecordDeleter extends RecordDeleter {
-    private final AtomicLong deleteCount = new AtomicLong();
-    private final long throwOnNthDelete;
-
-    InterruptingRecordDeleter(
-        DistributedStorage storage, String coordinatorNamespace, long throwOnNthDelete) {
-      super(storage, coordinatorNamespace);
-      this.throwOnNthDelete = throwOnNthDelete;
-    }
-
-    @Override
-    public void execute(Result scanResult) throws Exception {
-      if (deleteCount.incrementAndGet() >= throwOnNthDelete) {
-        throw new RuntimeException("Simulated interruption");
-      }
-      super.execute(scanResult);
-    }
   }
 }

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
@@ -13,7 +13,6 @@ import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,9 +32,6 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
 
   private static final Logger logger =
       LoggerFactory.getLogger(CoordinatorCleanupOrchestrator.class);
-
-  /** The number of deletions between successive progress log lines. */
-  private static final long PROGRESS_LOG_INTERVAL = 100_000L;
 
   private final DistributedStorage storage;
   private final ResumableScannerFactory scannerFactory;
@@ -221,34 +217,18 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
 
     logger.info("Starting to scan the coordinator table");
 
-    RecordDeletionChecker deletionChecker = new RecordDeletionChecker(deletableBeforeMs);
-    AtomicLong deletedCount = new AtomicLong();
+    DeleteCoordinatorStateHandler handler =
+        new DeleteCoordinatorStateHandler(
+            new RecordDeletionChecker(deletableBeforeMs), recordDeleter);
 
     try (ResumableScanner scanner = scannerFactory.create(scanCheckpointDir)) {
-
-      ScanResult scanResult =
-          scanner.scan(
-              coordinatorNamespace,
-              Coordinator.TABLE,
-              result -> {
-                if (deletionChecker.isDeletable(result)) {
-                  try {
-                    recordDeleter.execute(result);
-                  } catch (Exception e) {
-                    throw new RuntimeException(e);
-                  }
-                  long deleted = deletedCount.incrementAndGet();
-                  if (deleted % PROGRESS_LOG_INTERVAL == 0) {
-                    logger.info("Deleted {} records in this run so far.", deleted);
-                  }
-                }
-              });
+      ScanResult scanResult = scanner.scan(coordinatorNamespace, Coordinator.TABLE, handler);
 
       // The deletion count is per run (command execution) only. Tracking a cumulative total across
       // runs would require persisting it on every deletion, so we report only what this run did.
       logger.info("Finished scanning the coordinator table.");
       logger.info("Scanned records in this run: {}", scanResult.getTotalScanned());
-      logger.info("Deleted records in this run: {}", deletedCount.get());
+      logger.info("Deleted records in this run: {}", handler.getDeletedCount());
     }
   }
 

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/DeleteCoordinatorStateHandler.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/DeleteCoordinatorStateHandler.java
@@ -1,0 +1,50 @@
+package com.scalar.dl.tools.cleanup;
+
+import com.scalar.db.api.Result;
+import com.scalar.dl.tools.scan.RecordHandler;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link RecordHandler} for {@code coordinator-state-cleanup}.
+ *
+ * <p>For each scanned coordinator-state record it decides whether the record is deletable ({@link
+ * RecordDeletionChecker}) and, if so, deletes it ({@link RecordDeleter}).
+ */
+@ThreadSafe
+public final class DeleteCoordinatorStateHandler implements RecordHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(DeleteCoordinatorStateHandler.class);
+
+  /** The number of deletions between successive progress log lines. */
+  private static final long PROGRESS_LOG_INTERVAL = 100_000L;
+
+  private final RecordDeletionChecker deletionChecker;
+  private final RecordDeleter recordDeleter;
+  private final AtomicLong deletedCount = new AtomicLong();
+
+  public DeleteCoordinatorStateHandler(
+      RecordDeletionChecker deletionChecker, RecordDeleter recordDeleter) {
+    this.deletionChecker = deletionChecker;
+    this.recordDeleter = recordDeleter;
+  }
+
+  @Override
+  public void handle(Result record) throws Exception {
+    if (!deletionChecker.isDeletable(record)) {
+      return;
+    }
+    recordDeleter.execute(record);
+    long deleted = deletedCount.incrementAndGet();
+    if (deleted % PROGRESS_LOG_INTERVAL == 0) {
+      logger.info("Deleted {} records in this run so far.", deleted);
+    }
+  }
+
+  /** Returns the number of records deleted. */
+  public long getDeletedCount() {
+    return deletedCount.get();
+  }
+}

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
@@ -6,8 +6,10 @@ import com.scalar.db.api.Result;
 import com.scalar.db.io.Key;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** Deletes coordinator table records using {@link DistributedStorage}. */
+@ThreadSafe
 public final class RecordDeleter {
 
   private final DistributedStorage storage;

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
@@ -8,7 +8,7 @@ import com.scalar.db.transaction.consensuscommit.Coordinator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Deletes coordinator table records using {@link DistributedStorage}. */
-public class RecordDeleter {
+public final class RecordDeleter {
 
   private final DistributedStorage storage;
   private final String coordinatorNamespace;

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -65,7 +65,7 @@ class CoordinatorCleanupOrchestratorTest {
   }
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws Exception {
     storage = mock(DistributedStorage.class);
     scanner = mock(ResumableScanner.class);
     scannerFactory = mock(ResumableScannerFactory.class);

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -168,6 +168,24 @@ class CoordinatorCleanupOrchestratorTest {
   }
 
   @Test
+  void execute_scanFailureGiven_shouldNotMarkCompleted() throws Exception {
+    // Arrange
+    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
+        .thenThrow(new RuntimeException("Cosmos DB unavailable"));
+    CoordinatorCleanupOrchestrator orchestrator =
+        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
+
+    // Act
+    assertThatThrownBy(orchestrator::execute).isInstanceOf(RuntimeException.class);
+
+    // Assert
+    // The checkpoint must remain not-completed.
+    CoordinatorCleanupState state = new CoordinatorCleanupStateManager(tempDir).load();
+    assertThat(state).isNotNull();
+    assertThat(state.isCompleted()).isFalse();
+  }
+
+  @Test
   void execute_resumedStateGiven_shouldUsePreviousDeletableBeforeMs() throws Exception {
     // Arrange
     // Pre-persist state to simulate a resumed run

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -4,26 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
-import com.scalar.db.api.Result;
-import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.Attribute;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
-import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +23,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 
+@SuppressWarnings("resource")
 class CoordinatorCleanupOrchestratorTest {
 
   @TempDir Path tempDir;
@@ -78,60 +70,30 @@ class CoordinatorCleanupOrchestratorTest {
     scanner = mock(ResumableScanner.class);
     scannerFactory = mock(ResumableScannerFactory.class);
     when(scannerFactory.create(any())).thenReturn(scanner);
+    when(scanner.scan(any(), any(), any())).thenReturn(new ScanResult(0));
   }
 
-  private Result createMockResult(long createdAt) {
-    Result result = mock(Result.class);
-    when(result.isNull(Attribute.CREATED_AT)).thenReturn(false);
-    when(result.getBigInt(Attribute.CREATED_AT)).thenReturn(createdAt);
-    return result;
+  private CoordinatorCleanupOrchestrator newOrchestrator(
+      String coordinatorNamespace, String ledgerToken, String auditorToken) {
+    return new CoordinatorCleanupOrchestrator(
+        storage, scannerFactory, tempDir, coordinatorNamespace, ledgerToken, auditorToken);
   }
 
   @Test
-  void execute_shouldScanCoordinatorTableAndDeleteOnlyDeletableRecords() throws Exception {
+  void execute_initialRunGiven_shouldComputeBoundaryScanAndComplete() throws Exception {
     // Arrange
     String ledgerToken = createLedgerToken(2000L);
     String auditorToken = createAuditorToken(3000L);
-
-    Result deletable1 = createMockResult(1000L);
-    Result deletable2 = createMockResult(1999L);
-    Result notDeletable1 = createMockResult(2000L);
-    Result notDeletable2 = createMockResult(2500L);
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(deletable1);
-              consumer.accept(notDeletable1);
-              consumer.accept(deletable2);
-              consumer.accept(notDeletable2);
-              return new ScanResult(4);
-            });
-
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage,
-            scannerFactory,
-            tempDir,
-            Coordinator.NAMESPACE,
-            ledgerToken,
-            auditorToken,
-            mockDeleter);
+        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
 
     // Act
     orchestrator.execute();
 
     // Assert
     verify(scanner).scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any());
-    // Only the deletable records are deleted (and therefore counted); the rest are left intact.
-    verify(mockDeleter, times(2)).execute(any());
-    verify(mockDeleter).execute(deletable1);
-    verify(mockDeleter).execute(deletable2);
-    verify(mockDeleter, never()).execute(notDeletable1);
-    verify(mockDeleter, never()).execute(notDeletable2);
 
+    // The boundary (earlier of the two token timestamps) is observable via the persisted state.
     CoordinatorCleanupState state = new CoordinatorCleanupStateManager(tempDir).load();
     assertThat(state).isNotNull();
     assertThat(state.getDeletableBeforeMs()).isEqualTo(2000L);
@@ -146,11 +108,8 @@ class CoordinatorCleanupOrchestratorTest {
     completedState.markCompleted();
     stateManager.persist(completedState);
 
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, null, null, mockDeleter);
+        newOrchestrator(Coordinator.NAMESPACE, null, null);
 
     // Act
     orchestrator.execute();
@@ -158,7 +117,6 @@ class CoordinatorCleanupOrchestratorTest {
     // Assert
     verify(scannerFactory, never()).create(any());
     verify(scanner, never()).scan(any(), any(), any());
-    verify(mockDeleter, never()).execute(any());
   }
 
   @ParameterizedTest
@@ -167,22 +125,11 @@ class CoordinatorCleanupOrchestratorTest {
       long ledgerTimestamp, long auditorTimestamp, long expectedDeletableBeforeMs)
       throws Exception {
     // Arrange
-    String ledgerToken = createLedgerToken(ledgerTimestamp);
-    String auditorToken = createAuditorToken(auditorTimestamp);
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
-        .thenReturn(new ScanResult(0));
-
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage,
-            scannerFactory,
-            tempDir,
+        newOrchestrator(
             Coordinator.NAMESPACE,
-            ledgerToken,
-            auditorToken,
-            mockDeleter);
+            createLedgerToken(ledgerTimestamp),
+            createAuditorToken(auditorTimestamp));
 
     // Act
     orchestrator.execute();
@@ -199,74 +146,24 @@ class CoordinatorCleanupOrchestratorTest {
       String ledgerToken, String auditorToken) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  void execute_deleteFailureGiven_shouldStopProcessingAndPropagateException() throws Exception {
-    // Arrange
-    String ledgerToken = createLedgerToken(2000L);
-    String auditorToken = createAuditorToken(3000L);
-
-    Result record1 = createMockResult(1000L);
-    Result record2 = createMockResult(1500L);
-
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-    doThrow(new RuntimeException("DB unavailable")).when(mockDeleter).execute(record1);
-
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(record1);
-              consumer.accept(record2);
-              return new ScanResult(2);
-            });
-
-    CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage,
-            scannerFactory,
-            tempDir,
-            Coordinator.NAMESPACE,
-            ledgerToken,
-            auditorToken,
-            mockDeleter);
-
-    // Act & Assert
-    assertThatThrownBy(orchestrator::execute)
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("DB unavailable");
-    verify(mockDeleter, never()).execute(record2);
-
-    // Resumability is the core contract: a failed run must leave the checkpoint not-completed so
-    // that a re-invocation resumes instead of short-circuiting.
-    CoordinatorCleanupState state = new CoordinatorCleanupStateManager(tempDir).load();
-    assertThat(state).isNotNull();
-    assertThat(state.isCompleted()).isFalse();
-  }
-
-  @Test
   void execute_scanFailureGiven_shouldPropagateException() throws Exception {
     // Arrange
-    String ledgerToken = createLedgerToken(2000L);
-    String auditorToken = createAuditorToken(3000L);
     when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Cosmos DB unavailable");
-
     verify(scanner).close();
   }
 
@@ -277,31 +174,18 @@ class CoordinatorCleanupOrchestratorTest {
     CoordinatorCleanupStateManager stateManager = new CoordinatorCleanupStateManager(tempDir);
     stateManager.persist(new CoordinatorCleanupState(500L));
 
-    Result deletableRecord = createMockResult(400L);
-    Result nonDeletableRecord = createMockResult(600L);
-
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(deletableRecord);
-              consumer.accept(nonDeletableRecord);
-              return new ScanResult(2);
-            });
-
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, null, null, mockDeleter);
+        newOrchestrator(Coordinator.NAMESPACE, null, null);
 
     // Act
     orchestrator.execute();
 
     // Assert
-    // Should use the persisted deletable-before timestamp (500), not the token values
-    verify(mockDeleter).execute(deletableRecord);
-    verify(mockDeleter, never()).execute(nonDeletableRecord);
+    // The persisted boundary is reused (not recomputed) and the scan runs
+    verify(scanner).scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any());
+    CoordinatorCleanupState state = stateManager.load();
+    assertThat(state).isNotNull();
+    assertThat(state.getDeletableBeforeMs()).isEqualTo(500L);
   }
 
   @Test
@@ -311,41 +195,14 @@ class CoordinatorCleanupOrchestratorTest {
     stateManager.persist(new CoordinatorCleanupState(500L));
 
     // Tokens that would compute a different boundary (2000) if they were not ignored
-    String ledgerToken = createLedgerToken(2000L);
-    String auditorToken = createAuditorToken(3000L);
-
-    Result deletableRecord = createMockResult(400L);
-    Result nonDeletableRecord = createMockResult(600L);
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(deletableRecord);
-              consumer.accept(nonDeletableRecord);
-              return new ScanResult(2);
-            });
-
-    RecordDeleter mockDeleter = mock(RecordDeleter.class);
-
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage,
-            scannerFactory,
-            tempDir,
-            Coordinator.NAMESPACE,
-            ledgerToken,
-            auditorToken,
-            mockDeleter);
+        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
 
     // Act
     orchestrator.execute();
 
     // Assert
-    // The persisted boundary (500) is used, not the token-derived boundary (2000),
-    // so the record at 600 (deletable only under 2000) must be left intact.
-    verify(mockDeleter).execute(deletableRecord);
-    verify(mockDeleter, never()).execute(nonDeletableRecord);
-
+    // The persisted boundary (500) is kept, not the token-derived boundary (2000)
     CoordinatorCleanupState state = stateManager.load();
     assertThat(state).isNotNull();
     assertThat(state.getDeletableBeforeMs()).isEqualTo(500L);
@@ -357,8 +214,7 @@ class CoordinatorCleanupOrchestratorTest {
       String ledgerToken, String auditorToken) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
@@ -368,48 +224,24 @@ class CoordinatorCleanupOrchestratorTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
-  void execute_customCoordinatorNamespaceGiven_shouldScanAndDeleteInThatNamespace()
-      throws Exception {
+  void execute_customCoordinatorNamespaceGiven_shouldScanInThatNamespace() throws Exception {
     // Arrange
     String customNamespace = "my_coordinator";
-    String ledgerToken = createLedgerToken(2000L);
-    String auditorToken = createAuditorToken(3000L);
-
-    Result deletable = createMockResult(1000L);
-    when(deletable.getPartitionKey()).thenReturn(Optional.of(Key.ofText("tx_id", "tx-1")));
-    when(scanner.scan(eq(customNamespace), eq(Coordinator.TABLE), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(deletable);
-              return new ScanResult(1);
-            });
-
-    // Use a real RecordDeleter so the namespace it builds the Delete with is exercised too.
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, customNamespace, ledgerToken, auditorToken);
+        newOrchestrator(customNamespace, createLedgerToken(2000L), createAuditorToken(3000L));
 
     // Act
     orchestrator.execute();
 
     // Assert
     verify(scanner).scan(eq(customNamespace), eq(Coordinator.TABLE), any());
-    ArgumentCaptor<Delete> captor = ArgumentCaptor.forClass(Delete.class);
-    verify(storage).delete(captor.capture());
-    assertThat(captor.getValue().forNamespace()).hasValue(customNamespace);
-    assertThat(captor.getValue().forTable()).hasValue(Coordinator.TABLE);
   }
 
   @Test
   void close_shouldCloseStorage() {
     // Arrange
-    String ledgerToken = createLedgerToken(1000L);
-    String auditorToken = createAuditorToken(2000L);
     CoordinatorCleanupOrchestrator orchestrator =
-        new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, tempDir, Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(1000L), createAuditorToken(2000L));
 
     // Act
     orchestrator.close();

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/DeleteCoordinatorStateHandlerTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/DeleteCoordinatorStateHandlerTest.java
@@ -1,0 +1,92 @@
+package com.scalar.dl.tools.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeleteCoordinatorStateHandlerTest {
+
+  private RecordDeletionChecker deletionChecker;
+  private RecordDeleter recordDeleter;
+  private DeleteCoordinatorStateHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    deletionChecker = mock(RecordDeletionChecker.class);
+    recordDeleter = mock(RecordDeleter.class);
+    handler = new DeleteCoordinatorStateHandler(deletionChecker, recordDeleter);
+  }
+
+  @Test
+  void handle_deletableRecordGiven_shouldDeleteAndCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(deletionChecker.isDeletable(record)).thenReturn(true);
+
+    // Act
+    handler.handle(record);
+
+    // Assert
+    verify(recordDeleter).execute(record);
+    assertThat(handler.getDeletedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void handle_nonDeletableRecordGiven_shouldNotDeleteOrCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(deletionChecker.isDeletable(record)).thenReturn(false);
+
+    // Act
+    handler.handle(record);
+
+    // Assert
+    verify(recordDeleter, never()).execute(any());
+    assertThat(handler.getDeletedCount()).isZero();
+  }
+
+  @Test
+  void handle_mixedRecordsGiven_shouldDeleteAndCountOnlyDeletableOnes() throws Exception {
+    // Arrange
+    Result deletable1 = mock(Result.class);
+    Result deletable2 = mock(Result.class);
+    Result notDeletable = mock(Result.class);
+    when(deletionChecker.isDeletable(deletable1)).thenReturn(true);
+    when(deletionChecker.isDeletable(deletable2)).thenReturn(true);
+    when(deletionChecker.isDeletable(notDeletable)).thenReturn(false);
+
+    // Act
+    handler.handle(deletable1);
+    handler.handle(notDeletable);
+    handler.handle(deletable2);
+
+    // Assert
+    verify(recordDeleter).execute(deletable1);
+    verify(recordDeleter).execute(deletable2);
+    verify(recordDeleter, never()).execute(notDeletable);
+    assertThat(handler.getDeletedCount()).isEqualTo(2);
+  }
+
+  @Test
+  void handle_deleteFailureGiven_shouldPropagateExceptionAndNotCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(deletionChecker.isDeletable(record)).thenReturn(true);
+    doThrow(new RuntimeException("DB unavailable")).when(recordDeleter).execute(record);
+
+    // Act & Assert
+    assertThatThrownBy(() -> handler.handle(record))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("DB unavailable");
+    assertThat(handler.getDeletedCount()).isZero();
+  }
+}

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/FinalizeTransactionRecordHandler.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/FinalizeTransactionRecordHandler.java
@@ -1,0 +1,62 @@
+package com.scalar.dl.tools.cleanup;
+
+import com.scalar.db.api.Result;
+import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.dl.tools.scan.RecordHandler;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link RecordHandler} for {@code ledger-finalize-records}.
+ *
+ * <p>For each scanned record it decides whether the record needs finalization ({@link
+ * RecordStateChecker}) and, if so, finalizes it via ScalarDB recovery ({@link RecordFinalizer}).
+ */
+@ThreadSafe
+public final class FinalizeTransactionRecordHandler implements RecordHandler {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(FinalizeTransactionRecordHandler.class);
+
+  /** The number of finalizations between successive progress log lines. */
+  private static final long PROGRESS_LOG_INTERVAL = 100_000L;
+
+  private final RecordStateChecker stateChecker;
+  private final RecordFinalizer recordFinalizer;
+  private final String namespace;
+  private final String tableName;
+  private final AtomicLong finalizedCount = new AtomicLong();
+
+  public FinalizeTransactionRecordHandler(
+      RecordStateChecker stateChecker,
+      RecordFinalizer recordFinalizer,
+      String namespace,
+      String tableName) {
+    this.stateChecker = stateChecker;
+    this.recordFinalizer = recordFinalizer;
+    this.namespace = namespace;
+    this.tableName = tableName;
+  }
+
+  @Override
+  public void handle(Result record) throws Exception {
+    if (!stateChecker.needsFinalization(record)) {
+      return;
+    }
+    recordFinalizer.execute(namespace, tableName, record);
+    long finalized = finalizedCount.incrementAndGet();
+    if (finalized % PROGRESS_LOG_INTERVAL == 0) {
+      logger.info(
+          "Finalized {} records in table {} so far.",
+          finalized,
+          ScalarDbUtils.getFullTableName(namespace, tableName));
+    }
+  }
+
+  /** Returns the number of records finalized so far for this table. */
+  public long getFinalizedCount() {
+    return finalizedCount.get();
+  }
+}

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.Result;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
@@ -19,7 +18,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,21 +37,11 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
 
   private static final Logger logger = LoggerFactory.getLogger(LedgerFinalizeOrchestrator.class);
 
-  @VisibleForTesting
-  @FunctionalInterface
-  interface RecordFinalizerFactory {
-    RecordFinalizer create(
-        DistributedTransactionManager txManager,
-        DistributedStorage storage,
-        RecordStateChecker stateChecker);
-  }
-
   private final DistributedStorageAdmin admin;
   private final DistributedStorage storage;
   private final DistributedTransactionManager txManager;
   private final ResumableScannerFactory scannerFactory;
   private final Path checkpointDir;
-  private final RecordFinalizerFactory recordFinalizerFactory;
 
   @VisibleForTesting
   LedgerFinalizeOrchestrator(
@@ -62,23 +50,11 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
       DistributedTransactionManager txManager,
       ResumableScannerFactory scannerFactory,
       Path checkpointDir) {
-    this(admin, storage, txManager, scannerFactory, checkpointDir, RecordFinalizer::new);
-  }
-
-  @VisibleForTesting
-  LedgerFinalizeOrchestrator(
-      DistributedStorageAdmin admin,
-      DistributedStorage storage,
-      DistributedTransactionManager txManager,
-      ResumableScannerFactory scannerFactory,
-      Path checkpointDir,
-      RecordFinalizerFactory recordFinalizerFactory) {
     this.admin = admin;
     this.storage = storage;
     this.txManager = txManager;
     this.scannerFactory = scannerFactory;
     this.checkpointDir = checkpointDir;
-    this.recordFinalizerFactory = recordFinalizerFactory;
   }
 
   /**
@@ -205,27 +181,21 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
 
     logger.info("Starting to process the table: {}", qualifiedTable);
 
-    RecordFinalizer recordFinalizer =
-        recordFinalizerFactory.create(txManager, storage, stateChecker);
+    FinalizeTransactionRecordHandler handler =
+        new FinalizeTransactionRecordHandler(
+            stateChecker,
+            new RecordFinalizer(txManager, storage, stateChecker),
+            namespace,
+            tableName);
 
     try (ResumableScanner scanner = scannerFactory.create(scanCheckpointDir)) {
-      Consumer<Result> consumer =
-          result -> {
-            if (stateChecker.needsFinalization(result)) {
-              try {
-                recordFinalizer.execute(namespace, tableName, result);
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-            }
-          };
-
-      ScanResult scanResult = scanner.scan(namespace, tableName, consumer);
+      ScanResult scanResult = scanner.scan(namespace, tableName, handler);
 
       logger.info(
-          "Finished processing the table: {}. {} records were scanned.",
+          "Finished processing the table: {}. {} records were scanned, {} records were finalized.",
           qualifiedTable,
-          scanResult.getTotalScanned());
+          scanResult.getTotalScanned(),
+          handler.getFinalizedCount());
     }
 
     state.markTableCompleted(qualifiedTable);

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/RecordFinalizer.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/RecordFinalizer.java
@@ -12,8 +12,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** Finalizes non-terminal records by triggering ScalarDB recovery. */
+@ThreadSafe
 public final class RecordFinalizer {
 
   private final DistributedTransactionManager manager;

--- a/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/FinalizeTransactionRecordHandlerTest.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/FinalizeTransactionRecordHandlerTest.java
@@ -1,0 +1,98 @@
+package com.scalar.dl.tools.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FinalizeTransactionRecordHandlerTest {
+
+  private static final String NAMESPACE = "ns1";
+  private static final String TABLE = "tbl1";
+
+  private RecordStateChecker stateChecker;
+  private RecordFinalizer recordFinalizer;
+  private FinalizeTransactionRecordHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    stateChecker = mock(RecordStateChecker.class);
+    recordFinalizer = mock(RecordFinalizer.class);
+    handler = new FinalizeTransactionRecordHandler(stateChecker, recordFinalizer, NAMESPACE, TABLE);
+  }
+
+  @Test
+  void handle_recordNeedingFinalizationGiven_shouldFinalizeAndCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(stateChecker.needsFinalization(record)).thenReturn(true);
+
+    // Act
+    handler.handle(record);
+
+    // Assert
+    verify(recordFinalizer).execute(NAMESPACE, TABLE, record);
+    assertThat(handler.getFinalizedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void handle_terminalRecordGiven_shouldNotFinalizeOrCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(stateChecker.needsFinalization(record)).thenReturn(false);
+
+    // Act
+    handler.handle(record);
+
+    // Assert
+    verify(recordFinalizer, never()).execute(anyString(), anyString(), any());
+    assertThat(handler.getFinalizedCount()).isZero();
+  }
+
+  @Test
+  void handle_mixedRecordsGiven_shouldFinalizeAndCountOnlyNonTerminalOnes() throws Exception {
+    // Arrange
+    Result needsFinalization1 = mock(Result.class);
+    Result needsFinalization2 = mock(Result.class);
+    Result terminal = mock(Result.class);
+    when(stateChecker.needsFinalization(needsFinalization1)).thenReturn(true);
+    when(stateChecker.needsFinalization(needsFinalization2)).thenReturn(true);
+    when(stateChecker.needsFinalization(terminal)).thenReturn(false);
+
+    // Act
+    handler.handle(needsFinalization1);
+    handler.handle(terminal);
+    handler.handle(needsFinalization2);
+
+    // Assert
+    verify(recordFinalizer).execute(NAMESPACE, TABLE, needsFinalization1);
+    verify(recordFinalizer).execute(NAMESPACE, TABLE, needsFinalization2);
+    verify(recordFinalizer, never()).execute(NAMESPACE, TABLE, terminal);
+    assertThat(handler.getFinalizedCount()).isEqualTo(2);
+  }
+
+  @Test
+  void handle_finalizeFailureGiven_shouldPropagateExceptionAndNotCount() throws Exception {
+    // Arrange
+    Result record = mock(Result.class);
+    when(stateChecker.needsFinalization(record)).thenReturn(true);
+    doThrow(new RuntimeException("recovery failed"))
+        .when(recordFinalizer)
+        .execute(NAMESPACE, TABLE, record);
+
+    // Act & Assert
+    assertThatThrownBy(() -> handler.handle(record))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("recovery failed");
+    assertThat(handler.getFinalizedCount()).isZero();
+  }
+}

--- a/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
@@ -120,49 +120,54 @@ class LedgerFinalizeOrchestratorTest {
   }
 
   @Test
-  void execute_partialTableFailureGiven_shouldPersistPartialCompletionAndResumeSuccessfully()
-      throws Exception {
-    // Arrange 1
-    // First run discovers two tables, succeeds on the first, fails on the second
+  void execute_scanFailureGiven_shouldNotMarkCompleted() throws Exception {
+    // Arrange
+    // Discovers two tables, succeeds on the first, fails on the second.
     when(admin.getNamespaceNames()).thenReturn(new LinkedHashSet<>(Arrays.asList("ns1", "ns2")));
     when(admin.getNamespaceTableNames("ns1"))
         .thenReturn(new HashSet<>(Collections.singletonList("tbl1")));
     when(admin.getNamespaceTableNames("ns2"))
         .thenReturn(new HashSet<>(Collections.singletonList("tbl2")));
-
     when(scanner.scan(eq("ns1"), eq("tbl1"), any())).thenReturn(new ScanResult(10));
     when(scanner.scan(eq("ns2"), eq("tbl2"), any()))
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
 
-    // Act & Assert 1
     LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
+
+    // Act
     assertThatThrownBy(orchestrator::execute).isInstanceOf(RuntimeException.class);
 
-    // Verify first table's completion was persisted
-    LedgerFinalizeStateManager stateManager = new LedgerFinalizeStateManager(tempDir);
-    LedgerFinalizeState state = stateManager.load();
+    // Assert
+    // Only the finished table is marked completed; the failed table is left not-completed.
+    LedgerFinalizeState state = new LedgerFinalizeStateManager(tempDir).load();
     assertThat(state).isNotNull();
     assertThat(state.getCompletedTables()).containsExactly("ns1.tbl1");
-    long startedAtMs = state.getStartedAtMs();
+  }
 
-    // Arrange 2
-    // Resume — create a fresh scanner for the second run
-    ResumableScanner scanner2 = mock(ResumableScanner.class);
-    when(scannerFactory.create(any())).thenReturn(scanner2);
-    when(scanner2.scan(anyString(), anyString(), any())).thenReturn(new ScanResult(5));
+  @Test
+  void execute_resumedStateGiven_shouldSkipCompletedTablesAndProcessRemaining() throws Exception {
+    // Arrange
+    // Pre-persist a checkpoint where the first of two tables is already completed.
+    long startedAtMs = 1000L;
+    LedgerFinalizeStateManager stateManager = new LedgerFinalizeStateManager(tempDir);
+    stateManager.persist(
+        new LedgerFinalizeState(
+            startedAtMs,
+            Arrays.asList("ns1.tbl1", "ns2.tbl2"),
+            Collections.singletonList("ns1.tbl1")));
+    when(scanner.scan(anyString(), anyString(), any())).thenReturn(new ScanResult(5));
 
-    // Act 2
-    LedgerFinalizeOrchestrator orchestrator2 = newOrchestrator();
-    String token = orchestrator2.execute();
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
 
-    // Assert 2
-    assertThat(token).isNotEmpty();
-    CompletionToken decoded = CompletionToken.decode(token);
-    assertThat(decoded.getStartedAtMs()).isEqualTo(startedAtMs);
+    // Act
+    String token = orchestrator.execute();
 
-    // Second table was processed, first was skipped
-    verify(scanner2, never()).scan(eq("ns1"), eq("tbl1"), any());
-    verify(scanner2).scan(eq("ns2"), eq("tbl2"), any());
+    // Assert
+    // The completed table is skipped; only the remaining table is scanned.
+    verify(scanner, never()).scan(eq("ns1"), eq("tbl1"), any());
+    verify(scanner).scan(eq("ns2"), eq("tbl2"), any());
+    // The original start timestamp is carried over across the resume.
+    assertThat(CompletionToken.decode(token).getStartedAtMs()).isEqualTo(startedAtMs);
   }
 
   @Test

--- a/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
@@ -14,28 +14,20 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
-import com.scalar.db.api.Result;
-import com.scalar.db.api.TransactionState;
-import com.scalar.db.io.BigIntColumn;
-import com.scalar.db.io.IntColumn;
-import com.scalar.db.transaction.consensuscommit.Attribute;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@SuppressWarnings("resource")
 class LedgerFinalizeOrchestratorTest {
 
   @TempDir Path tempDir;
@@ -56,25 +48,12 @@ class LedgerFinalizeOrchestratorTest {
     when(scannerFactory.create(any())).thenReturn(scanner);
   }
 
-  /**
-   * Creates a mock {@link Result} that {@link RecordStateChecker} can inspect. Follows the same
-   * pattern as {@link RecordStateCheckerTest}.
-   */
-  private Result createMockResult(TransactionState txState, long txPreparedAt) {
-    Result result = mock(Result.class);
-    Map<String, com.scalar.db.io.Column<?>> columns = new LinkedHashMap<>();
-    columns.put(Attribute.STATE, IntColumn.of(Attribute.STATE, txState.get()));
-    columns.put(Attribute.PREPARED_AT, BigIntColumn.of(Attribute.PREPARED_AT, txPreparedAt));
-    when(result.getColumns()).thenReturn(columns);
-    when(result.isNull(Attribute.STATE)).thenReturn(false);
-    when(result.getInt(Attribute.STATE)).thenReturn(txState.get());
-    when(result.isNull(Attribute.PREPARED_AT)).thenReturn(false);
-    when(result.getBigInt(Attribute.PREPARED_AT)).thenReturn(txPreparedAt);
-    return result;
+  private LedgerFinalizeOrchestrator newOrchestrator() {
+    return new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
   }
 
   @Test
-  void execute_initialRunGiven_shouldDiscoverTablesAndScanAndReturnToken() throws Exception {
+  void execute_initialRunGiven_shouldDiscoverTablesScanAndReturnToken() throws Exception {
     // Arrange
     when(admin.getNamespaceNames()).thenReturn(new HashSet<>(Arrays.asList("ns1", "ns2")));
     when(admin.getNamespaceTableNames("ns1"))
@@ -83,8 +62,7 @@ class LedgerFinalizeOrchestratorTest {
         .thenReturn(new HashSet<>(Collections.singletonList("tbl2")));
     when(scanner.scan(anyString(), anyString(), any())).thenReturn(new ScanResult(10));
 
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
 
     // Act
     long before = System.currentTimeMillis();
@@ -92,11 +70,11 @@ class LedgerFinalizeOrchestratorTest {
     long after = System.currentTimeMillis();
 
     // Assert
-    assertThat(completionToken).isNotEmpty();
     CompletionToken token = CompletionToken.decode(completionToken);
     assertThat(token.getServerType()).isEqualTo(CompletionToken.ServerType.LEDGER);
     assertThat(token.getStartedAtMs()).isBetween(before, after);
 
+    // Each discovered table is scanned and the scanner is closed per table.
     verify(scanner).scan(eq("ns1"), eq("tbl1"), any());
     verify(scanner).scan(eq("ns2"), eq("tbl2"), any());
     verify(scanner, times(2)).close();
@@ -112,8 +90,7 @@ class LedgerFinalizeOrchestratorTest {
     // Arrange
     when(admin.getNamespaceNames()).thenReturn(Collections.emptySet());
 
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
 
     // Act
     String completionToken = orchestrator.execute();
@@ -132,8 +109,7 @@ class LedgerFinalizeOrchestratorTest {
     when(scanner.scan(eq("ns1"), eq("tbl1"), any()))
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
 
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
@@ -141,51 +117,6 @@ class LedgerFinalizeOrchestratorTest {
         .hasMessageContaining("Cosmos DB unavailable");
 
     verify(scanner).close();
-  }
-
-  @Test
-  void execute_nonTerminalAndTerminalRecordsGiven_shouldProcessOnlyNonTerminalRecordsInWindow()
-      throws Exception {
-    // Arrange
-    // Use pre-persisted state to specify guaranteeTimestamp
-    long guaranteeTimestamp = 1000L;
-    LedgerFinalizeStateManager stateManager = new LedgerFinalizeStateManager(tempDir);
-    stateManager.persist(
-        new LedgerFinalizeState(
-            guaranteeTimestamp, Collections.singletonList("ns1.tbl1"), new ArrayList<>()));
-
-    Result preparedInWindow = createMockResult(TransactionState.PREPARED, 500L);
-    Result committedRecord = createMockResult(TransactionState.COMMITTED, 500L);
-    Result preparedOutsideWindow = createMockResult(TransactionState.PREPARED, 2000L);
-
-    when(scanner.scan(eq("ns1"), eq("tbl1"), any()))
-        .thenAnswer(
-            invocation -> {
-              Consumer<Result> consumer = invocation.getArgument(2);
-              consumer.accept(preparedInWindow);
-              consumer.accept(committedRecord);
-              consumer.accept(preparedOutsideWindow);
-              return new ScanResult(3);
-            });
-
-    RecordFinalizer mockFinalizer = mock(RecordFinalizer.class);
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(
-            admin,
-            storage,
-            txManager,
-            scannerFactory,
-            tempDir,
-            (mgr, stor, checker) -> mockFinalizer);
-
-    // Act
-    orchestrator.execute();
-
-    // Assert
-    // Only the PREPARED record within the guarantee window should be finalized
-    verify(mockFinalizer).execute("ns1", "tbl1", preparedInWindow);
-    verify(mockFinalizer, never()).execute(anyString(), anyString(), eq(committedRecord));
-    verify(mockFinalizer, never()).execute(anyString(), anyString(), eq(preparedOutsideWindow));
   }
 
   @Test
@@ -204,8 +135,7 @@ class LedgerFinalizeOrchestratorTest {
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
 
     // Act & Assert 1
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
     assertThatThrownBy(orchestrator::execute).isInstanceOf(RuntimeException.class);
 
     // Verify first table's completion was persisted
@@ -222,8 +152,7 @@ class LedgerFinalizeOrchestratorTest {
     when(scanner2.scan(anyString(), anyString(), any())).thenReturn(new ScanResult(5));
 
     // Act 2
-    LedgerFinalizeOrchestrator orchestrator2 =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator2 = newOrchestrator();
     String token = orchestrator2.execute();
 
     // Assert 2
@@ -239,8 +168,7 @@ class LedgerFinalizeOrchestratorTest {
   @Test
   void close_shouldCloseAdminAndStorageAndTxManager() {
     // Arrange
-    LedgerFinalizeOrchestrator orchestrator =
-        new LedgerFinalizeOrchestrator(admin, storage, txManager, scannerFactory, tempDir);
+    LedgerFinalizeOrchestrator orchestrator = newOrchestrator();
 
     // Act
     orchestrator.close();

--- a/coordinator-state-deleter/resumable-scan/src/integration-test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerIntegrationTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/integration-test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerIntegrationTest.java
@@ -23,7 +23,6 @@ import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.cosmos.CosmosUtils;
 import com.scalar.dl.tools.scan.RecordHandler;
 import com.scalar.dl.tools.scan.ScanResult;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -213,7 +212,7 @@ class CosmosResumableScannerIntegrationTest {
   }
 
   @Test
-  void scan_withoutInterruption_shouldScanAllRecords(@TempDir Path checkpointDir) {
+  void scan_withoutInterruption_shouldScanAllRecords(@TempDir Path checkpointDir) throws Exception {
     // Arrange
     Set<String> threadNames = ConcurrentHashMap.newKeySet();
     AtomicLong count = new AtomicLong();
@@ -272,7 +271,7 @@ class CosmosResumableScannerIntegrationTest {
 
   @Test
   void scan_interruptedAndResumed_shouldCoverAllRecords(@TempDir Path checkpointDir)
-      throws IOException {
+      throws Exception {
     // Arrange 1
     // First scan interrupted halfway
     Set<String> firstScannedRecordIds = ConcurrentHashMap.newKeySet();

--- a/coordinator-state-deleter/resumable-scan/src/integration-test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerIntegrationTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/integration-test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerIntegrationTest.java
@@ -21,6 +21,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.cosmos.CosmosUtils;
+import com.scalar.dl.tools.scan.RecordHandler;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -199,10 +199,10 @@ class CosmosResumableScannerIntegrationTest {
    *
    * @param recordIds the set to collect scanned record IDs into
    * @param threshold the number of records after which to simulate an interruption
-   * @return a Consumer that collects record IDs into {@code recordIds} and throws a {@link
+   * @return a RecordHandler that collects record IDs into {@code recordIds} and throws a {@link
    *     RuntimeException} after being invoked {@code threshold} times
    */
-  private static Consumer<Result> interruptingConsumerAfter(Set<String> recordIds, int threshold) {
+  private static RecordHandler interruptingHandlerAfter(Set<String> recordIds, int threshold) {
     AtomicLong count = new AtomicLong();
     return r -> {
       recordIds.add(recordId(r));
@@ -285,7 +285,7 @@ class CosmosResumableScannerIntegrationTest {
         scanner.scan(
             NAMESPACE,
             TABLE,
-            interruptingConsumerAfter(firstScannedRecordIds, TEST_RECORD_COUNT / 2));
+            interruptingHandlerAfter(firstScannedRecordIds, TEST_RECORD_COUNT / 2));
       } catch (Exception e) {
         // Ignore expected interruption
       }
@@ -338,7 +338,7 @@ class CosmosResumableScannerIntegrationTest {
         scanner.scan(
             NAMESPACE,
             TABLE,
-            interruptingConsumerAfter(firstScannedRecordIds, TEST_RECORD_COUNT * 3 / 4));
+            interruptingHandlerAfter(firstScannedRecordIds, TEST_RECORD_COUNT * 3 / 4));
       } catch (Exception e) {
         // Ignore expected interruption
       }
@@ -395,7 +395,7 @@ class CosmosResumableScannerIntegrationTest {
         new CosmosResumableScanner(databaseConfig, checkpointDir)) {
       try {
         scanner.scan(
-            NAMESPACE, TABLE, interruptingConsumerAfter(scannedRecordIds, TEST_RECORD_COUNT / 2));
+            NAMESPACE, TABLE, interruptingHandlerAfter(scannedRecordIds, TEST_RECORD_COUNT / 2));
       } catch (Exception e) {
         // Ignore expected interruption
       }
@@ -450,7 +450,7 @@ class CosmosResumableScannerIntegrationTest {
           scanner.scan(
               NAMESPACE,
               TABLE,
-              interruptingConsumerAfter(firstScannedRecordIds, TEST_RECORD_COUNT / 2));
+              interruptingHandlerAfter(firstScannedRecordIds, TEST_RECORD_COUNT / 2));
         } catch (Exception e) {
           // Ignore expected interruption
         }

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/RecordHandler.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/RecordHandler.java
@@ -1,0 +1,21 @@
+package com.scalar.dl.tools.scan;
+
+import com.scalar.db.api.Result;
+
+/**
+ * Callback invoked by {@link ResumableScanner} for each scanned record.
+ *
+ * <p>Implementations must be thread-safe: the scanner invokes the handler concurrently from
+ * multiple scan worker threads (one per physical partition).
+ */
+@FunctionalInterface
+public interface RecordHandler {
+
+  /**
+   * Handles a single scanned record.
+   *
+   * @param record the scanned record
+   * @throws Exception if handling fails; the scan is aborted and the exception is propagated
+   */
+  void handle(Result record) throws Exception;
+}

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScanner.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScanner.java
@@ -1,14 +1,10 @@
 package com.scalar.dl.tools.scan;
 
-import com.scalar.db.api.Result;
-import java.util.function.Consumer;
-
 /**
  * A resumable, parallel scanner over a ScalarDB table.
  *
- * <p>Callers specify a ScalarDB namespace and table name; the scanner delivers each record as a
- * {@link Result} via the provided callback. Progress is checkpointed to enable
- * resume-after-failure.
+ * <p>Callers specify a ScalarDB namespace and table name; the scanner delivers each record to the
+ * provided {@link RecordHandler}. Progress is checkpointed to enable resume-after-failure.
  */
 public interface ResumableScanner extends AutoCloseable {
 
@@ -17,8 +13,8 @@ public interface ResumableScanner extends AutoCloseable {
    *
    * @param namespace ScalarDB namespace of the table to scan
    * @param tableName ScalarDB table name to scan
-   * @param recordConsumer callback invoked for each scanned record; must be thread-safe
+   * @param recordHandler callback invoked for each scanned record; must be thread-safe
    * @return the scan result
    */
-  ScanResult scan(String namespace, String tableName, Consumer<Result> recordConsumer);
+  ScanResult scan(String namespace, String tableName, RecordHandler recordHandler);
 }

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScanner.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/ResumableScanner.java
@@ -15,6 +15,8 @@ public interface ResumableScanner extends AutoCloseable {
    * @param tableName ScalarDB table name to scan
    * @param recordHandler callback invoked for each scanned record; must be thread-safe
    * @return the scan result
+   * @throws Exception if the scan fails; an exception thrown by {@code recordHandler} propagates
+   *     as-is
    */
-  ScanResult scan(String namespace, String tableName, RecordHandler recordHandler);
+  ScanResult scan(String namespace, String tableName, RecordHandler recordHandler) throws Exception;
 }

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.scalar.db.api.DistributedStorageAdmin;
-import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
@@ -17,6 +16,7 @@ import com.scalar.db.storage.cosmos.CosmosConfig;
 import com.scalar.db.storage.cosmos.CosmosUtils;
 import com.scalar.db.storage.cosmos.ResultInterpreter;
 import com.scalar.db.util.ScalarDbUtils;
+import com.scalar.dl.tools.scan.RecordHandler;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,11 +99,11 @@ public final class CosmosResumableScanner implements ResumableScanner {
   }
 
   @Override
-  public ScanResult scan(String namespace, String tableName, Consumer<Result> recordConsumer) {
+  public ScanResult scan(String namespace, String tableName, RecordHandler recordHandler) {
     try {
       String qualifiedTableName = ScalarDbUtils.getFullTableName(namespace, tableName);
       checkpointManager.initCheckpointFor(qualifiedTableName);
-      ScanResult result = doScan(namespace, tableName, recordConsumer);
+      ScanResult result = doScan(namespace, tableName, recordHandler);
       checkpointManager.clearCheckpointFor(qualifiedTableName);
       return result;
     } catch (RuntimeException e) {
@@ -116,7 +115,7 @@ public final class CosmosResumableScanner implements ResumableScanner {
     }
   }
 
-  private ScanResult doScan(String namespace, String tableName, Consumer<Result> recordConsumer)
+  private ScanResult doScan(String namespace, String tableName, RecordHandler recordHandler)
       throws Exception {
 
     // Resolve Cosmos database and container from namespace and table name
@@ -165,7 +164,7 @@ public final class CosmosResumableScanner implements ResumableScanner {
                 feedRangeId,
                 qualifiedTableName,
                 continuationToken,
-                recordConsumer,
+                recordHandler,
                 resultInterpreter,
                 checkpointManager,
                 maxItemCount);

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScanner.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -99,20 +100,17 @@ public final class CosmosResumableScanner implements ResumableScanner {
   }
 
   @Override
-  public ScanResult scan(String namespace, String tableName, RecordHandler recordHandler) {
-    try {
-      String qualifiedTableName = ScalarDbUtils.getFullTableName(namespace, tableName);
-      checkpointManager.initCheckpointFor(qualifiedTableName);
-      ScanResult result = doScan(namespace, tableName, recordHandler);
-      checkpointManager.clearCheckpointFor(qualifiedTableName);
-      return result;
-    } catch (RuntimeException e) {
-      // Re-throw directly to avoid wrapping in the catch-all below
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Scan failed for " + ScalarDbUtils.getFullTableName(namespace, tableName), e);
-    }
+  public ScanResult scan(String namespace, String tableName, RecordHandler recordHandler)
+      throws Exception {
+    Objects.requireNonNull(namespace, "namespace must not be null");
+    Objects.requireNonNull(tableName, "tableName must not be null");
+    Objects.requireNonNull(recordHandler, "recordHandler must not be null");
+
+    String qualifiedTableName = ScalarDbUtils.getFullTableName(namespace, tableName);
+    checkpointManager.initCheckpointFor(qualifiedTableName);
+    ScanResult result = doScan(namespace, tableName, recordHandler);
+    checkpointManager.clearCheckpointFor(qualifiedTableName);
+    return result;
   }
 
   private ScanResult doScan(String namespace, String tableName, RecordHandler recordHandler)

--- a/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosScanWorker.java
+++ b/coordinator-state-deleter/resumable-scan/src/main/java/com/scalar/dl/tools/scan/cosmos/CosmosScanWorker.java
@@ -8,8 +8,8 @@ import com.azure.cosmos.util.CosmosPagedIterable;
 import com.scalar.db.api.Result;
 import com.scalar.db.storage.cosmos.Record;
 import com.scalar.db.storage.cosmos.ResultInterpreter;
+import com.scalar.dl.tools.scan.RecordHandler;
 import java.util.concurrent.Callable;
-import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
  * Scans a single FeedRange of a Cosmos container.
  *
  * <p>Iterates pages via CosmosPagedIterable, converts each Cosmos document to a ScalarDB Result via
- * {@link ResultInterpreter}, delivers it to the consumer, and checkpoints the continuation token
- * after each page.
+ * {@link ResultInterpreter}, delivers it to the {@link RecordHandler}, and checkpoints the
+ * continuation token after each page.
  *
  * <p>Does NOT use setMaxDegreeOfParallelism (per design §7.4.2).
  */
@@ -32,7 +32,7 @@ class CosmosScanWorker implements Callable<Long> {
   private final String feedRangeId;
   private final String tableName;
   @Nullable private final String continuationToken;
-  private final Consumer<Result> recordConsumer;
+  private final RecordHandler recordHandler;
   private final ResultInterpreter resultInterpreter;
   private final CheckpointManager checkpointManager;
   private final int maxItemCount;
@@ -43,7 +43,7 @@ class CosmosScanWorker implements Callable<Long> {
       String feedRangeId,
       String tableName,
       @Nullable String continuationToken,
-      Consumer<Result> recordConsumer,
+      RecordHandler recordHandler,
       ResultInterpreter resultInterpreter,
       CheckpointManager checkpointManager,
       int maxItemCount) {
@@ -52,7 +52,7 @@ class CosmosScanWorker implements Callable<Long> {
     this.feedRangeId = feedRangeId;
     this.tableName = tableName;
     this.continuationToken = continuationToken;
-    this.recordConsumer = recordConsumer;
+    this.recordHandler = recordHandler;
     this.resultInterpreter = resultInterpreter;
     this.checkpointManager = checkpointManager;
     this.maxItemCount = maxItemCount;
@@ -83,7 +83,7 @@ class CosmosScanWorker implements Callable<Long> {
       }
       for (Record record : page.getResults()) {
         Result result = resultInterpreter.interpret(record);
-        recordConsumer.accept(result);
+        recordHandler.handle(result);
         scanned++;
       }
 

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
@@ -24,13 +24,13 @@ import com.scalar.db.api.Result;
 import com.scalar.db.api.TableMetadata;
 import com.scalar.db.io.DataType;
 import com.scalar.db.storage.cosmos.Record;
+import com.scalar.dl.tools.scan.RecordHandler;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,8 +40,7 @@ class CosmosResumableScannerTest {
   private static final String TABLE = "table";
   private static final String QUALIFIED_TABLE = NAMESPACE + "." + TABLE;
 
-  @SuppressWarnings("unchecked")
-  private final Consumer<Result> consumer = mock(Consumer.class);
+  private final RecordHandler recordHandler = mock(RecordHandler.class);
 
   private CosmosClient cosmosClient;
   private CosmosDatabase cosmosDatabase;
@@ -102,7 +101,7 @@ class CosmosResumableScannerTest {
 
     // Act
     try (CosmosResumableScanner scanner = createScanner()) {
-      scanner.scan(NAMESPACE, TABLE, consumer);
+      scanner.scan(NAMESPACE, TABLE, recordHandler);
     }
 
     // Assert
@@ -126,7 +125,7 @@ class CosmosResumableScannerTest {
 
     // Act
     try (CosmosResumableScanner scanner = createScanner()) {
-      scanner.scan(NAMESPACE, TABLE, consumer);
+      scanner.scan(NAMESPACE, TABLE, recordHandler);
     }
 
     // Assert
@@ -143,7 +142,7 @@ class CosmosResumableScannerTest {
 
     // Act & Assert
     try (CosmosResumableScanner scanner = createScanner()) {
-      ScanResult result = scanner.scan(NAMESPACE, TABLE, consumer);
+      ScanResult result = scanner.scan(NAMESPACE, TABLE, recordHandler);
       assertThat(result.getTotalScanned()).isEqualTo(5);
     }
   }
@@ -168,7 +167,7 @@ class CosmosResumableScannerTest {
 
     // Act & Assert
     try (CosmosResumableScanner scanner = createScanner()) {
-      ScanResult result = scanner.scan(NAMESPACE, TABLE, consumer);
+      ScanResult result = scanner.scan(NAMESPACE, TABLE, recordHandler);
       assertThat(result.getTotalScanned()).isEqualTo(6);
     }
   }
@@ -194,7 +193,7 @@ class CosmosResumableScannerTest {
 
     // Act
     try (CosmosResumableScanner scanner = createScanner()) {
-      ScanResult result = scanner.scan(NAMESPACE, TABLE, consumer);
+      ScanResult result = scanner.scan(NAMESPACE, TABLE, recordHandler);
 
       // Assert
       assertThat(result.getTotalScanned()).isEqualTo(1);
@@ -203,15 +202,15 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_workerThrowsException_shouldPropagateException() {
+  void scan_workerThrowsException_shouldPropagateException() throws Exception {
     // Arrange
     setupSingleFeedRange(1);
     setupNoCheckpoint();
-    doThrow(new RuntimeException("worker error")).when(consumer).accept(any(Result.class));
+    doThrow(new RuntimeException("worker error")).when(recordHandler).handle(any(Result.class));
 
     // Act & Assert
     try (CosmosResumableScanner scanner = createScanner()) {
-      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, consumer))
+      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, recordHandler))
           .isInstanceOf(RuntimeException.class)
           .hasMessage("worker error");
     }
@@ -227,7 +226,7 @@ class CosmosResumableScannerTest {
 
     // Act & Assert
     try (CosmosResumableScanner scanner = createScanner()) {
-      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, consumer))
+      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, recordHandler))
           .isInstanceOf(IllegalStateException.class);
     }
   }
@@ -267,8 +266,8 @@ class CosmosResumableScannerTest {
     try (CosmosResumableScanner scanner = createScanner()) {
       assertThatCode(
               () -> {
-                scanner.scan(NAMESPACE, TABLE, consumer);
-                scanner.scan(NAMESPACE, table2, consumer);
+                scanner.scan(NAMESPACE, TABLE, recordHandler);
+                scanner.scan(NAMESPACE, table2, recordHandler);
               })
           .doesNotThrowAnyException();
     }
@@ -282,7 +281,7 @@ class CosmosResumableScannerTest {
 
     // Act
     try (CosmosResumableScanner scanner = createScanner()) {
-      scanner.scan(NAMESPACE, TABLE, consumer);
+      scanner.scan(NAMESPACE, TABLE, recordHandler);
     }
 
     // Assert
@@ -290,15 +289,15 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_doScanFails_shouldNotClearCheckpoints() {
+  void scan_doScanFails_shouldNotClearCheckpoints() throws Exception {
     // Arrange
     setupSingleFeedRange(1);
     setupNoCheckpoint();
-    doThrow(new RuntimeException("worker error")).when(consumer).accept(any(Result.class));
+    doThrow(new RuntimeException("worker error")).when(recordHandler).handle(any(Result.class));
 
     // Act
     try (CosmosResumableScanner scanner = createScanner()) {
-      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, consumer))
+      assertThatThrownBy(() -> scanner.scan(NAMESPACE, TABLE, recordHandler))
           .isInstanceOf(RuntimeException.class);
     }
 
@@ -359,7 +358,7 @@ class CosmosResumableScannerTest {
     try (CosmosResumableScanner scanner =
         new CosmosResumableScanner(
             cosmosClient, checkpointManager, storageAdmin, maxWorkerThreads, maxItemCount)) {
-      scanner.scan(NAMESPACE, TABLE, consumer);
+      scanner.scan(NAMESPACE, TABLE, recordHandler);
     }
 
     // Assert
@@ -372,7 +371,7 @@ class CosmosResumableScannerTest {
     setupSingleFeedRange(0);
     setupNoCheckpoint();
     CosmosResumableScanner scanner = createScanner();
-    scanner.scan(NAMESPACE, TABLE, consumer);
+    scanner.scan(NAMESPACE, TABLE, recordHandler);
 
     // Act
     scanner.close();

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosResumableScannerTest.java
@@ -94,7 +94,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_noPersistedFeedRanges_shouldDiscoverAndPersistFeedRanges() {
+  void scan_noPersistedFeedRanges_shouldDiscoverAndPersistFeedRanges() throws Exception {
     // Arrange
     setupSingleFeedRange(1);
     setupNoCheckpoint();
@@ -110,7 +110,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_persistedFeedRangesExist_shouldLoadFromCheckpoint() {
+  void scan_persistedFeedRangesExist_shouldLoadFromCheckpoint() throws Exception {
     // Arrange
     FeedRange feedRange = FeedRange.forFullRange();
     String persistedJson = "[\"" + FeedRangeSerializer.toJson(feedRange) + "\"]";
@@ -135,7 +135,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_singleFeedRange_shouldReturnTotalScanned() {
+  void scan_singleFeedRange_shouldReturnTotalScanned() throws Exception {
     // Arrange
     setupSingleFeedRange(5);
     setupNoCheckpoint();
@@ -148,7 +148,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_multipleFeedRanges_shouldSumCounts() {
+  void scan_multipleFeedRanges_shouldSumCounts() throws Exception {
     // Arrange
     FeedRange range1 = createMockFeedRange("r1");
     FeedRange range2 = createMockFeedRange("r2");
@@ -173,7 +173,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_continuationTokenExists_shouldResumeFromToken() {
+  void scan_continuationTokenExists_shouldResumeFromToken() throws Exception {
     // Arrange
     FeedRange feedRange = createMockFeedRange("full");
     String feedRangeId = FeedRangeSerializer.toId(feedRange);
@@ -274,7 +274,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_doScanSucceeds_shouldClearAllCheckpoints() {
+  void scan_doScanSucceeds_shouldClearAllCheckpoints() throws Exception {
     // Arrange
     setupSingleFeedRange(1);
     setupNoCheckpoint();
@@ -306,7 +306,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_withCustomMaxWorkerThreads_shouldLimitThreadCount() {
+  void scan_withCustomMaxWorkerThreads_shouldLimitThreadCount() throws Exception {
     // Arrange
     FeedRange range1 = createMockFeedRange("r1");
     FeedRange range2 = createMockFeedRange("r2");
@@ -338,7 +338,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void scan_withCustomMaxItemCount_shouldPassMaxItemCountToWorkers() {
+  void scan_withCustomMaxItemCount_shouldPassMaxItemCountToWorkers() throws Exception {
     // Arrange
     int maxWorkerThreads = 32;
     int maxItemCount = 50;
@@ -366,7 +366,7 @@ class CosmosResumableScannerTest {
   }
 
   @Test
-  void close_shouldCloseClientAndStorageAdmin() {
+  void close_shouldCloseClientAndStorageAdmin() throws Exception {
     // Arrange
     setupSingleFeedRange(0);
     setupNoCheckpoint();

--- a/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosScanWorkerTest.java
+++ b/coordinator-state-deleter/resumable-scan/src/test/java/com/scalar/dl/tools/scan/cosmos/CosmosScanWorkerTest.java
@@ -19,10 +19,10 @@ import com.azure.cosmos.util.CosmosPagedIterable;
 import com.scalar.db.api.Result;
 import com.scalar.db.storage.cosmos.Record;
 import com.scalar.db.storage.cosmos.ResultInterpreter;
+import com.scalar.dl.tools.scan.RecordHandler;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +32,7 @@ class CosmosScanWorkerTest {
   private static final String RANGE_ID = "range1";
   private static final int DEFAULT_MAX_ITEM_COUNT = 100;
 
-  @SuppressWarnings("unchecked")
-  private final Consumer<Result> consumer = mock(Consumer.class);
+  private final RecordHandler recordHandler = mock(RecordHandler.class);
 
   private CosmosContainer container;
   private FeedRange feedRange;
@@ -58,7 +57,7 @@ class CosmosScanWorkerTest {
         RANGE_ID,
         TABLE_NAME,
         continuationToken,
-        consumer,
+        recordHandler,
         resultInterpreter,
         checkpointManager,
         maxItemCount);
@@ -78,7 +77,7 @@ class CosmosScanWorkerTest {
 
     // Assert
     assertThat(count).isEqualTo(3);
-    verify(consumer, times(3)).accept(any(Result.class));
+    verify(recordHandler, times(3)).handle(any(Result.class));
   }
 
   @Test
@@ -100,7 +99,7 @@ class CosmosScanWorkerTest {
   }
 
   @Test
-  void call_emptyResult_shouldReturnZeroAndNotCallConsumer() throws Exception {
+  void call_emptyResult_shouldReturnZeroAndNotCallHandler() throws Exception {
     // Arrange
     FeedResponse<Record> page = CosmosMockHelper.createMockPage(Collections.emptyList(), null);
     CosmosPagedIterable<Record> iterable =
@@ -112,7 +111,7 @@ class CosmosScanWorkerTest {
 
     // Assert
     assertThat(count).isEqualTo(0);
-    verify(consumer, never()).accept(any());
+    verify(recordHandler, never()).handle(any());
   }
 
   @Test
@@ -187,7 +186,7 @@ class CosmosScanWorkerTest {
   }
 
   @Test
-  void call_shouldPassInterpretedResultsToConsumer() throws Exception {
+  void call_shouldPassInterpretedResultsToHandler() throws Exception {
     // Arrange
     Result mockResult = mock(Result.class);
     when(resultInterpreter.interpret(any(Record.class))).thenReturn(mockResult);
@@ -202,7 +201,7 @@ class CosmosScanWorkerTest {
     createWorker(null).call();
 
     // Assert
-    verify(consumer).accept(mockResult);
+    verify(recordHandler).handle(mockResult);
   }
 
   @Test
@@ -222,7 +221,7 @@ class CosmosScanWorkerTest {
   }
 
   @Test
-  void call_consumerThrowsException_shouldPropagateException() {
+  void call_handlerThrowsException_shouldPropagateException() throws Exception {
     // Arrange
     List<Record> records = CosmosMockHelper.createMockRecords(1);
     FeedResponse<Record> page = CosmosMockHelper.createMockPage(records, null);
@@ -230,11 +229,11 @@ class CosmosScanWorkerTest {
         CosmosMockHelper.createMockPagedIterable(Collections.singletonList(page));
     container = CosmosMockHelper.createMockContainer(iterable, Collections.emptyList());
 
-    doThrow(new RuntimeException("consumer error")).when(consumer).accept(any(Result.class));
+    doThrow(new RuntimeException("handler error")).when(recordHandler).handle(any(Result.class));
 
     // Act & Assert
     assertThatThrownBy(() -> createWorker(null).call())
         .isInstanceOf(RuntimeException.class)
-        .hasMessage("consumer error");
+        .hasMessage("handler error");
   }
 }


### PR DESCRIPTION
## Description

This refactoring PR introduces a per-record handler for Resumable scan.

The per-record _check & act_ logic for each command is used to live inline in the orchestrators' scan callbacks, making the orchestrators do too much and duplicating that logic in their tests.

This PR introduces a `RecordHandler` abstraction so each command's per-record work lives in a small, independently tested class, leaving the orchestrators to own only discovery, checkpointing, and the scan flow.

## Related issues and/or PRs

Depends on:

N/A

## Changes made

  - Add a `RecordHandler` callback interface and switch `ResumableScanner.scan(...)` to it instead of `Consumer<Result>`, allowing handlers to throw checked exceptions directly.
  - Extract the per-record decide-dispatch-count logic into `RecordHandler` implementations:
    - `DeleteCoordinatorStateHandler`
    - `FinalizeTransactionRecordHandler`
  - Move per-record selection and counting tests into the new handler tests, and scope the orchestrator tests to orchestration concerns (state, tokens, resume, scan wiring).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A