### PR TITLE
Add error codes and messages for the command

### DIFF
--- a/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -27,9 +27,9 @@ public final class LockFinalizer {
   public void execute(String namespace, Result result) {
     String assetId = result.getText(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     if (assetId == null) {
-      // The id column is the partition key of the asset_lock table, so it can never be null for a
-      // real record.
-      throw new AssertionError(
+      // The id column is the partition key of the asset_lock table, so it should never be null for
+      // a real record; guard against unexpected/corrupted data.
+      throw new IllegalStateException(
           "Column "
               + AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME
               + " not found in the result");

--- a/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -5,6 +5,8 @@ import com.scalar.dl.auditor.ordering.LockRecoveryResult;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** Finalizes unreleased asset locks by issuing {@code RecoverAssetLock} RPCs to the Auditor. */
@@ -25,10 +27,12 @@ public final class LockFinalizer {
   public void execute(String namespace, Result result) {
     String assetId = result.getText(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     if (assetId == null) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Column %s not found in result",
-              AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME));
+      // The id column is the partition key of the asset_lock table, so it can never be null for a
+      // real record.
+      throw new AssertionError(
+          "Column "
+              + AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME
+              + " not found in the result");
     }
 
     AssetLockRecoveryRequest rpcRequest =
@@ -36,9 +40,8 @@ public final class LockFinalizer {
 
     LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
     if (rpcResult == LockRecoveryResult.FAILED) {
-      throw new RuntimeException(
-          String.format(
-              "RecoverAssetLock RPC failed for asset %s in namespace %s", assetId, namespace));
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.RECOVER_ASSET_LOCK_RPC_FAILED, assetId, namespace);
     }
 
     // TODO: NOT_RECOVERABLE means the lock is still active and currently aborts the whole run. A

--- a/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -13,6 +13,8 @@ import com.scalar.dl.auditor.ordering.LockRecoveryResult;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -71,7 +73,7 @@ class LockFinalizerTest {
 
     // Act & Assert — the RPC is never issued for a record without an asset id.
     assertThatThrownBy(() -> finalizer.execute("default", result))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(AssertionError.class)
         .hasMessageContaining(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     verify(auditorClient, never()).recover(any(AssetLockRecoveryRequest.class));
   }
@@ -96,8 +98,9 @@ class LockFinalizerTest {
 
     // Act & Assert
     assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("RPC failed");
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.RECOVER_ASSET_LOCK_RPC_FAILED.buildCode());
   }
 
   @Test

--- a/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -73,7 +73,7 @@ class LockFinalizerTest {
 
     // Act & Assert — the RPC is never issued for a record without an asset id.
     assertThatThrownBy(() -> finalizer.execute("default", result))
-        .isInstanceOf(AssertionError.class)
+        .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     verify(auditorClient, never()).recover(any(AssetLockRecoveryRequest.class));
   }

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/Category.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/Category.java
@@ -1,0 +1,30 @@
+package com.scalar.dl.tools.common;
+
+import java.util.Objects;
+
+/**
+ * The category of an error raised by the coordinator-state-deletion tools.
+ *
+ * <p>The category id is embedded in the error code (see {@link ScalarDlToolsError#buildCode()}) so
+ * that the class of an error is recognizable from its code alone.
+ */
+public enum Category {
+  /** An error caused by incorrect usage, such as an invalid argument or configuration. */
+  USER_ERROR("1"),
+  /** An error caused by an unexpected internal condition, such as an I/O or data error. */
+  INTERNAL_ERROR("2");
+
+  private final String id;
+
+  Category(String id) {
+    Objects.requireNonNull(id, "The id must not be null.");
+    if (id.length() != 1) {
+      throw new IllegalArgumentException("The length of the id must be 1.");
+    }
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/Category.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/Category.java
@@ -17,7 +17,7 @@ public enum Category {
   private final String id;
 
   Category(String id) {
-    Objects.requireNonNull(id, "The id must not be null.");
+    Objects.requireNonNull(id);
     if (id.length() != 1) {
       throw new IllegalArgumentException("The length of the id must be 1.");
     }

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CompletionToken.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CompletionToken.java
@@ -51,7 +51,8 @@ public final class CompletionToken {
    *
    * @param encoded the base64url-encoded token string
    * @return the decoded completion token
-   * @throws IllegalArgumentException if the string cannot be decoded or the CRC32C does not match
+   * @throws CoordinatorStateDeleterException if the string cannot be decoded or the CRC32C does not
+   *     match
    */
   public static CompletionToken decode(String encoded) {
     try {
@@ -64,14 +65,15 @@ public final class CompletionToken {
 
       String expected = computeCrc32c(serverValue, startedAtMs);
       if (!expected.equals(crc)) {
-        throw new IllegalArgumentException(
-            "CRC32C mismatch: expected " + expected + " but got " + crc);
+        throw new CoordinatorStateDeleterException(
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_CRC_MISMATCH, expected, crc);
       }
       return new CompletionToken(serverType, startedAtMs, crc);
-    } catch (IllegalArgumentException e) {
+    } catch (CoordinatorStateDeleterException e) {
       throw e;
     } catch (Exception e) {
-      throw new IllegalArgumentException("Failed to decode completion token", e);
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED, e);
     }
   }
 
@@ -135,7 +137,8 @@ public final class CompletionToken {
           return s;
         }
       }
-      throw new IllegalArgumentException("Unknown server type: " + value);
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.UNKNOWN_SERVER_TYPE, value);
     }
 
     public String getValue() {

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
@@ -1,0 +1,129 @@
+package com.scalar.dl.tools.common;
+
+/**
+ * The errors raised by the ScalarDL coordinator-state-deletion tools.
+ *
+ * <p>Every error has a code of the form {@code DL-TOOLS-<categoryId><id>} (e.g. {@code
+ * DL-TOOLS-1001}). The ids are sequential within each {@link Category}.
+ */
+public enum CoordinatorStateDeleterError implements ScalarDlToolsError {
+
+  //
+  // Errors for the user error category
+  //
+  COMPLETION_TOKEN_CRC_MISMATCH(
+      Category.USER_ERROR,
+      "001",
+      "CRC32C mismatch in the completion token: expected %s but got %s.",
+      "",
+      "Verify that the completion token was copied verbatim and is not truncated or altered."),
+  COMPLETION_TOKEN_DECODE_FAILED(
+      Category.USER_ERROR,
+      "002",
+      "Failed to decode the completion token.",
+      "",
+      "Verify that the completion token was copied verbatim and is not truncated or altered."),
+  UNKNOWN_SERVER_TYPE(
+      Category.USER_ERROR,
+      "003",
+      "Unknown server type in the completion token: %s.",
+      "",
+      "Verify that the completion token was copied verbatim and is not truncated or altered."),
+  BOTH_COMPLETION_TOKENS_REQUIRED(
+      Category.USER_ERROR,
+      "004",
+      "Both ledger and auditor completion tokens are required for the initial run.",
+      "",
+      "Provide both the ledger and auditor completion tokens emitted by the finalization commands."),
+  LEDGER_TOKEN_WRONG_SERVER_TYPE(
+      Category.USER_ERROR,
+      "005",
+      "The ledger token has the wrong server type: %s.",
+      "",
+      "Provide the token emitted by 'ledger-finalize-records' as the ledger completion token."),
+  AUDITOR_TOKEN_WRONG_SERVER_TYPE(
+      Category.USER_ERROR,
+      "006",
+      "The auditor token has the wrong server type: %s.",
+      "",
+      "Provide the token emitted by 'auditor-finalize-records' as the auditor completion token."),
+  AUDITOR_COMPLETION_TOKEN_REQUIRED(
+      Category.USER_ERROR,
+      "007",
+      "The auditor completion token is required for the initial run.",
+      "",
+      "Provide the auditor completion token emitted by 'auditor-finalize-records'."),
+
+  //
+  // Errors for the internal error category
+  //
+  STATE_LOAD_FAILED(
+      Category.INTERNAL_ERROR,
+      "001",
+      "Failed to load the state from %s.",
+      "",
+      "Verify that the checkpoint directory is readable and the state file is not corrupted."),
+  STATE_PERSIST_FAILED(
+      Category.INTERNAL_ERROR,
+      "002",
+      "Failed to persist the state to %s.",
+      "",
+      "Verify that the checkpoint directory is writable and has sufficient free space."),
+  RECOVER_ASSET_LOCK_RPC_FAILED(
+      Category.INTERNAL_ERROR,
+      "003",
+      "The asset lock recovery failed for asset %s in namespace %s.",
+      "",
+      "Verify that the Auditor is healthy and reachable.");
+
+  private static final String COMPONENT_NAME = "DL-TOOLS";
+
+  private final Category category;
+  private final String id;
+  private final String message;
+  private final String cause;
+  private final String solution;
+
+  CoordinatorStateDeleterError(
+      Category category, String id, String message, String cause, String solution) {
+    validate(COMPONENT_NAME, category, id, message, cause, solution);
+
+    this.category = category;
+    this.id = id;
+    this.message = message;
+    this.cause = cause;
+    this.solution = solution;
+  }
+
+  @Override
+  public String getComponentName() {
+    return COMPONENT_NAME;
+  }
+
+  @Override
+  public Category getCategory() {
+    return category;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @SuppressWarnings("unused")
+  @Override
+  public String getCause() {
+    return cause;
+  }
+
+  @SuppressWarnings("unused")
+  @Override
+  public String getSolution() {
+    return solution;
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterException.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterException.java
@@ -1,5 +1,7 @@
 package com.scalar.dl.tools.common;
 
+import java.util.Objects;
+
 /**
  * The exception thrown by the coordinator-state-deletion tools.
  *
@@ -13,21 +15,21 @@ public class CoordinatorStateDeleterException extends RuntimeException {
 
   public CoordinatorStateDeleterException(String message, Category category) {
     super(message);
-    this.category = category;
+    this.category = Objects.requireNonNull(category);
   }
 
   public CoordinatorStateDeleterException(String message, Throwable cause, Category category) {
     super(message, cause);
-    this.category = category;
+    this.category = Objects.requireNonNull(category);
   }
 
   public CoordinatorStateDeleterException(ScalarDlToolsError error, Object... args) {
-    this(error.buildMessage(args), error.getCategory());
+    this(Objects.requireNonNull(error).buildMessage(args), error.getCategory());
   }
 
   public CoordinatorStateDeleterException(
       ScalarDlToolsError error, Throwable cause, Object... args) {
-    this(error.buildMessage(args), cause, error.getCategory());
+    this(Objects.requireNonNull(error).buildMessage(args), cause, error.getCategory());
   }
 
   public Category getCategory() {

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterException.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterException.java
@@ -1,0 +1,36 @@
+package com.scalar.dl.tools.common;
+
+/**
+ * The exception thrown by the coordinator-state-deletion tools.
+ *
+ * <p>It is constructed from a {@link ScalarDlToolsError} so that the message is prefixed with a
+ * structured error code (e.g. {@code DL-TOOLS-1001}) and the originating {@link Category} is
+ * preserved.
+ */
+public class CoordinatorStateDeleterException extends RuntimeException {
+
+  private final Category category;
+
+  public CoordinatorStateDeleterException(String message, Category category) {
+    super(message);
+    this.category = category;
+  }
+
+  public CoordinatorStateDeleterException(String message, Throwable cause, Category category) {
+    super(message, cause);
+    this.category = category;
+  }
+
+  public CoordinatorStateDeleterException(ScalarDlToolsError error, Object... args) {
+    this(error.buildMessage(args), error.getCategory());
+  }
+
+  public CoordinatorStateDeleterException(
+      ScalarDlToolsError error, Throwable cause, Object... args) {
+    this(error.buildMessage(args), cause, error.getCategory());
+  }
+
+  public Category getCategory() {
+    return category;
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/FileUtils.java
@@ -27,7 +27,7 @@ public final class FileUtils {
     if (fileName == null) {
       throw new IllegalArgumentException("The target path must have a file name");
     }
-    Path tmp = target.resolveSibling(fileName.toString() + ".tmp");
+    Path tmp = target.resolveSibling(fileName + ".tmp");
     try {
       Files.write(tmp, content);
       Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
@@ -1,0 +1,72 @@
+package com.scalar.dl.tools.common;
+
+import java.util.Objects;
+
+/**
+ * A structured error definition for the ScalarDL coordinator-state-deletion tools.
+ *
+ * <p>This mirrors the error framework used by ScalarDL and ScalarDB: every error carries a {@link
+ * Category}, a component name, a unique id, a message, a probable cause, and a suggested solution.
+ * Implementations are typically enums (see {@link CoordinatorStateDeleterError}).
+ */
+public interface ScalarDlToolsError {
+
+  String getComponentName();
+
+  Category getCategory();
+
+  String getId();
+
+  String getMessage();
+
+  String getCause();
+
+  String getSolution();
+
+  // This method validates the error. It is called in the constructor of the enum to ensure that the
+  // error is valid.
+  default void validate(
+      String componentName,
+      Category category,
+      String id,
+      String message,
+      String cause,
+      String solution) {
+    Objects.requireNonNull(componentName, "The component name must not be null.");
+    Objects.requireNonNull(category, "The category must not be null.");
+
+    Objects.requireNonNull(id, "The id must not be null.");
+    if (id.length() != 3) {
+      throw new IllegalArgumentException("The length of the id must be 3.");
+    }
+
+    Objects.requireNonNull(message, "The message must not be null.");
+    Objects.requireNonNull(cause, "The cause must not be null.");
+    Objects.requireNonNull(solution, "The solution must not be null.");
+  }
+
+  /**
+   * Builds the error code. The code is built as follows:
+   *
+   * <p>{@code <componentName>-<categoryId><id>}
+   *
+   * @return the built code
+   */
+  default String buildCode() {
+    return getComponentName() + "-" + getCategory().getId() + getId();
+  }
+
+  /**
+   * Builds the error message with the given arguments. The message is built as follows:
+   *
+   * <p>{@code <componentName>-<categoryId><id>: <message>}
+   *
+   * @param args the arguments to be formatted into the message
+   * @return the formatted message
+   */
+  default String buildMessage(Object... args) {
+    return buildCode()
+        + ": "
+        + (args.length == 0 ? getMessage() : String.format(getMessage(), args));
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
@@ -32,17 +32,17 @@ public interface ScalarDlToolsError {
       String message,
       String cause,
       String solution) {
-    Objects.requireNonNull(componentName, "The component name must not be null.");
-    Objects.requireNonNull(category, "The category must not be null.");
+    Objects.requireNonNull(componentName);
+    Objects.requireNonNull(category);
 
-    Objects.requireNonNull(id, "The id must not be null.");
+    Objects.requireNonNull(id);
     if (id.length() != 3) {
       throw new IllegalArgumentException("The length of the id must be 3.");
     }
 
-    Objects.requireNonNull(message, "The message must not be null.");
-    Objects.requireNonNull(cause, "The cause must not be null.");
-    Objects.requireNonNull(solution, "The solution must not be null.");
+    Objects.requireNonNull(message);
+    Objects.requireNonNull(cause);
+    Objects.requireNonNull(solution);
   }
 
   /**
@@ -67,6 +67,6 @@ public interface ScalarDlToolsError {
   default String buildMessage(Object... args) {
     return buildCode()
         + ": "
-        + (args.length == 0 ? getMessage() : String.format(getMessage(), args));
+        + (args == null || args.length == 0 ? getMessage() : String.format(getMessage(), args));
   }
 }

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StateManager.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StateManager.java
@@ -40,7 +40,7 @@ public abstract class StateManager<T> {
    * Loads the persisted state from the checkpoint directory.
    *
    * @return the deserialized state, or {@code null} if no state file exists
-   * @throws RuntimeException if the state file exists but cannot be read or parsed
+   * @throws CoordinatorStateDeleterException if the state file exists but cannot be read or parsed
    */
   @Nullable
   public T load() {
@@ -52,7 +52,8 @@ public abstract class StateManager<T> {
       byte[] bytes = Files.readAllBytes(statePath);
       return mapper.readValue(bytes, stateClass);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to load state from " + statePath, e);
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.STATE_LOAD_FAILED, e, statePath);
     }
   }
 
@@ -61,7 +62,7 @@ public abstract class StateManager<T> {
    * it does not exist.
    *
    * @param state the state object to persist
-   * @throws RuntimeException if the state cannot be serialized or written
+   * @throws CoordinatorStateDeleterException if the state cannot be serialized or written
    */
   public void persist(T state) {
     try {
@@ -69,7 +70,8 @@ public abstract class StateManager<T> {
       byte[] content = mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(state);
       FileUtils.writeAtomic(stateDir.resolve(STATE_FILE), content);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to persist state to " + stateDir.resolve(STATE_FILE), e);
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.STATE_PERSIST_FAILED, e, stateDir.resolve(STATE_FILE));
     }
   }
 

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CompletionTokenTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CompletionTokenTest.java
@@ -3,6 +3,9 @@ package com.scalar.dl.tools.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
 class CompletionTokenTest {
@@ -79,19 +82,20 @@ class CompletionTokenTest {
   }
 
   @Test
-  void decode_corruptedCrcGiven_shouldThrowException() {
-    // Arrange
-    CompletionToken token =
-        CompletionToken.create(CompletionToken.ServerType.LEDGER, 1745000000000L);
-    String encoded = token.encode();
-    // Corrupt one character
-    char[] chars = encoded.toCharArray();
-    chars[chars.length - 1] = chars[chars.length - 1] == 'A' ? 'B' : 'A';
-    String corrupted = new String(chars);
+  void decode_crcMismatchGiven_shouldThrowExceptionWithCrcMismatchCode() {
+    // Arrange: a well-formed token payload whose CRC32C does not match its contents.
+    String json =
+        "{\"server_type\":\"ledger\",\"started_at_ms\":1745000000000,\"crc32c\":\"deadbeef\"}";
+    String encoded =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(json.getBytes(StandardCharsets.UTF_8));
 
     // Act & Assert
-    assertThatThrownBy(() -> CompletionToken.decode(corrupted))
-        .isInstanceOf(CoordinatorStateDeleterException.class);
+    assertThatThrownBy(() -> CompletionToken.decode(encoded))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_CRC_MISMATCH.buildCode());
   }
 
   @Test
@@ -100,19 +104,26 @@ class CompletionTokenTest {
 
     // Act & Assert
     assertThatThrownBy(() -> CompletionToken.decode("!!!not-base64!!!"))
-        .isInstanceOf(CoordinatorStateDeleterException.class);
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED.buildCode())
+        .hasCauseInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void decode_invalidJsonGiven_shouldThrowException() {
-    // Arrange
-    CompletionToken token =
-        CompletionToken.create(CompletionToken.ServerType.LEDGER, 1745000000000L);
-    String encoded = token.encode();
-    String truncated = encoded.substring(0, encoded.length() / 2);
+    // Arrange: valid base64url whose decoded payload is not valid JSON, so decoding fails while
+    // parsing the JSON (as opposed to while decoding base64).
+    String encoded =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString("{not valid json}".getBytes(StandardCharsets.UTF_8));
 
     // Act & Assert
-    assertThatThrownBy(() -> CompletionToken.decode(truncated))
-        .isInstanceOf(CoordinatorStateDeleterException.class);
+    assertThatThrownBy(() -> CompletionToken.decode(encoded))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED.buildCode())
+        .hasCauseInstanceOf(JsonProcessingException.class);
   }
 }

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CompletionTokenTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CompletionTokenTest.java
@@ -79,7 +79,7 @@ class CompletionTokenTest {
   }
 
   @Test
-  void decode_corruptedCrcGiven_shouldThrowIllegalArgumentException() {
+  void decode_corruptedCrcGiven_shouldThrowException() {
     // Arrange
     CompletionToken token =
         CompletionToken.create(CompletionToken.ServerType.LEDGER, 1745000000000L);
@@ -91,20 +91,20 @@ class CompletionTokenTest {
 
     // Act & Assert
     assertThatThrownBy(() -> CompletionToken.decode(corrupted))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(CoordinatorStateDeleterException.class);
   }
 
   @Test
-  void decode_invalidBase64Given_shouldThrowIllegalArgumentException() {
+  void decode_invalidBase64Given_shouldThrowException() {
     // Arrange
 
     // Act & Assert
     assertThatThrownBy(() -> CompletionToken.decode("!!!not-base64!!!"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(CoordinatorStateDeleterException.class);
   }
 
   @Test
-  void decode_invalidJsonGiven_shouldThrowIllegalArgumentException() {
+  void decode_invalidJsonGiven_shouldThrowException() {
     // Arrange
     CompletionToken token =
         CompletionToken.create(CompletionToken.ServerType.LEDGER, 1745000000000L);
@@ -113,6 +113,6 @@ class CompletionTokenTest {
 
     // Act & Assert
     assertThatThrownBy(() -> CompletionToken.decode(truncated))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(CoordinatorStateDeleterException.class);
   }
 }

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CoordinatorStateDeleterErrorTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CoordinatorStateDeleterErrorTest.java
@@ -1,0 +1,80 @@
+package com.scalar.dl.tools.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class CoordinatorStateDeleterErrorTest {
+
+  @Test
+  void values_shouldNotHaveDuplicateErrorCodes() {
+    assertThat(
+            Arrays.stream(CoordinatorStateDeleterError.values())
+                .map(CoordinatorStateDeleterError::buildCode))
+        .doesNotHaveDuplicates();
+  }
+
+  @Test
+  void values_shouldAllHaveThreeDigitIds() {
+    // The constructor already calls validate(), so simply constructing every value asserts that the
+    // id length is 3. This test makes the intent explicit.
+    for (CoordinatorStateDeleterError error : CoordinatorStateDeleterError.values()) {
+      assertThat(error.getId()).hasSize(3);
+      assertThat(error.getComponentName()).isEqualTo("DL-TOOLS");
+    }
+  }
+
+  @Test
+  void buildCode_userErrorGiven_shouldBuildCorrectCode() {
+    // Arrange
+    CoordinatorStateDeleterError error = CoordinatorStateDeleterError.COMPLETION_TOKEN_CRC_MISMATCH;
+
+    // Act
+    String code = error.buildCode();
+
+    // Assert
+    assertThat(code).isEqualTo("DL-TOOLS-1001");
+  }
+
+  @Test
+  void buildCode_internalErrorGiven_shouldBuildCorrectCode() {
+    // Arrange
+    CoordinatorStateDeleterError error = CoordinatorStateDeleterError.STATE_LOAD_FAILED;
+
+    // Act
+    String code = error.buildCode();
+
+    // Assert
+    assertThat(code).isEqualTo("DL-TOOLS-2001");
+  }
+
+  @Test
+  void buildMessage_noArgsGiven_shouldPrefixCodeToMessage() {
+    // Arrange
+    CoordinatorStateDeleterError error =
+        CoordinatorStateDeleterError.BOTH_COMPLETION_TOKENS_REQUIRED;
+
+    // Act
+    String message = error.buildMessage();
+
+    // Assert
+    assertThat(message)
+        .isEqualTo(
+            "DL-TOOLS-1004: Both ledger and auditor completion tokens are required for the "
+                + "initial run.");
+  }
+
+  @Test
+  void buildMessage_argsGiven_shouldFormatMessage() {
+    // Arrange
+    CoordinatorStateDeleterError error = CoordinatorStateDeleterError.UNKNOWN_SERVER_TYPE;
+
+    // Act
+    String message = error.buildMessage("foo");
+
+    // Assert
+    assertThat(message)
+        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+  }
+}

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CoordinatorStateDeleterExceptionTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/CoordinatorStateDeleterExceptionTest.java
@@ -1,0 +1,51 @@
+package com.scalar.dl.tools.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CoordinatorStateDeleterExceptionTest {
+
+  @Test
+  void constructor_errorGiven_shouldBuildMessageAndCarryCategory() {
+    // Arrange & Act
+    CoordinatorStateDeleterException exception =
+        new CoordinatorStateDeleterException(
+            CoordinatorStateDeleterError.AUDITOR_COMPLETION_TOKEN_REQUIRED);
+
+    // Assert
+    assertThat(exception.getMessage())
+        .isEqualTo("DL-TOOLS-1007: The auditor completion token is required for the initial run.");
+    assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
+  }
+
+  @Test
+  void constructor_errorWithArgsGiven_shouldFormatMessage() {
+    // Arrange & Act
+    CoordinatorStateDeleterException exception =
+        new CoordinatorStateDeleterException(
+            CoordinatorStateDeleterError.UNKNOWN_SERVER_TYPE, "foo");
+
+    // Assert
+    assertThat(exception.getMessage())
+        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+    assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
+  }
+
+  @Test
+  void constructor_errorWithCauseGiven_shouldRetainCause() {
+    // Arrange
+    Exception cause = new IllegalStateException("boom");
+
+    // Act
+    CoordinatorStateDeleterException exception =
+        new CoordinatorStateDeleterException(
+            CoordinatorStateDeleterError.STATE_LOAD_FAILED, cause, "/tmp/state");
+
+    // Assert
+    assertThat(exception.getMessage())
+        .isEqualTo("DL-TOOLS-2001: Failed to load the state from /tmp/state.");
+    assertThat(exception.getCause()).isSameAs(cause);
+    assertThat(exception.getCategory()).isEqualTo(Category.INTERNAL_ERROR);
+  }
+}

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
@@ -7,6 +7,8 @@ import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -168,8 +170,8 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
     }
 
     if (ledgerTokenString == null || auditorTokenString == null) {
-      throw new IllegalArgumentException(
-          "Both ledger and auditor completion tokens are required for the initial run");
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.BOTH_COMPLETION_TOKENS_REQUIRED);
     }
 
     long deletableBeforeMs = parseAndComputeDeletableBeforeMs();
@@ -186,14 +188,15 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
   private long parseAndComputeDeletableBeforeMs() {
     CompletionToken ledgerToken = CompletionToken.decode(ledgerTokenString);
     if (ledgerToken.getServerType() != CompletionToken.ServerType.LEDGER) {
-      throw new IllegalArgumentException(
-          "Ledger token has wrong server type: " + ledgerToken.getServerType());
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.LEDGER_TOKEN_WRONG_SERVER_TYPE, ledgerToken.getServerType());
     }
 
     CompletionToken auditorToken = CompletionToken.decode(auditorTokenString);
     if (auditorToken.getServerType() != CompletionToken.ServerType.AUDITOR) {
-      throw new IllegalArgumentException(
-          "Auditor token has wrong server type: " + auditorToken.getServerType());
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.AUDITOR_TOKEN_WRONG_SERVER_TYPE,
+          auditorToken.getServerType());
     }
 
     long ledgerTimestamp = ledgerToken.getStartedAtMs();

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -142,14 +144,13 @@ class CoordinatorCleanupOrchestratorTest {
 
   @ParameterizedTest
   @MethodSource("invalidTokenProvider")
-  void execute_invalidTokenGiven_shouldThrowIllegalArgumentException(
-      String ledgerToken, String auditorToken) {
+  void execute_invalidTokenGiven_shouldThrowException(String ledgerToken, String auditorToken) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
         newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
-    assertThatThrownBy(orchestrator::execute).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(orchestrator::execute).isInstanceOf(CoordinatorStateDeleterException.class);
   }
 
   @Test
@@ -228,7 +229,7 @@ class CoordinatorCleanupOrchestratorTest {
 
   @ParameterizedTest
   @MethodSource("missingTokenProvider")
-  void execute_noCheckpointAndMissingTokenGiven_shouldThrowIllegalArgumentException(
+  void execute_noCheckpointAndMissingTokenGiven_shouldThrowException(
       String ledgerToken, String auditorToken) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
@@ -236,9 +237,9 @@ class CoordinatorCleanupOrchestratorTest {
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(CoordinatorStateDeleterException.class)
         .hasMessageContaining(
-            "Both ledger and auditor completion tokens are required for the initial run");
+            CoordinatorStateDeleterError.BOTH_COMPLETION_TOKENS_REQUIRED.buildCode());
   }
 
   @Test

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -58,12 +58,28 @@ class CoordinatorCleanupOrchestratorTest {
   }
 
   static Stream<Arguments> invalidTokenProvider() {
-    String invalidCrc = "aW52YWxpZC10b2tlbg"; // base64url("invalid-token")
+    String undecodableToken = "aW52YWxpZC10b2tlbg"; // base64url("invalid-token"), not valid JSON
     return Stream.of(
-        Arguments.of(invalidCrc, createAuditorToken(1000L)),
-        Arguments.of(createLedgerToken(1000L), invalidCrc),
-        Arguments.of(createAuditorToken(1000L), createAuditorToken(2000L)),
-        Arguments.of(createLedgerToken(1000L), createLedgerToken(2000L)));
+        // An undecodable ledger token.
+        Arguments.of(
+            undecodableToken,
+            createAuditorToken(1000L),
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED),
+        // An undecodable auditor token.
+        Arguments.of(
+            createLedgerToken(1000L),
+            undecodableToken,
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED),
+        // An auditor token supplied in the ledger slot.
+        Arguments.of(
+            createAuditorToken(1000L),
+            createAuditorToken(2000L),
+            CoordinatorStateDeleterError.LEDGER_TOKEN_WRONG_SERVER_TYPE),
+        // A ledger token supplied in the auditor slot.
+        Arguments.of(
+            createLedgerToken(1000L),
+            createLedgerToken(2000L),
+            CoordinatorStateDeleterError.AUDITOR_TOKEN_WRONG_SERVER_TYPE));
   }
 
   @BeforeEach
@@ -144,13 +160,16 @@ class CoordinatorCleanupOrchestratorTest {
 
   @ParameterizedTest
   @MethodSource("invalidTokenProvider")
-  void execute_invalidTokenGiven_shouldThrowException(String ledgerToken, String auditorToken) {
+  void execute_invalidTokenGiven_shouldThrowException(
+      String ledgerToken, String auditorToken, CoordinatorStateDeleterError expected) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
         newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
-    assertThatThrownBy(orchestrator::execute).isInstanceOf(CoordinatorStateDeleterException.class);
+    assertThatThrownBy(orchestrator::execute)
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(expected.buildCode());
   }
 
   @Test

--- a/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestrator.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestrator.java
@@ -6,6 +6,8 @@ import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -170,8 +172,8 @@ public final class RequestProofCleanupOrchestrator implements AutoCloseable {
     }
 
     if (auditorTokenString == null) {
-      throw new IllegalArgumentException(
-          "The auditor completion token is required for the initial run");
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.AUDITOR_COMPLETION_TOKEN_REQUIRED);
     }
 
     long deletableBeforeMs = parseDeletableBeforeMs();
@@ -188,8 +190,9 @@ public final class RequestProofCleanupOrchestrator implements AutoCloseable {
   private long parseDeletableBeforeMs() {
     CompletionToken auditorToken = CompletionToken.decode(auditorTokenString);
     if (auditorToken.getServerType() != CompletionToken.ServerType.AUDITOR) {
-      throw new IllegalArgumentException(
-          "Auditor token has wrong server type: " + auditorToken.getServerType());
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.AUDITOR_TOKEN_WRONG_SERVER_TYPE,
+          auditorToken.getServerType());
     }
 
     long guaranteeTimestamp = auditorToken.getStartedAtMs();

--- a/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofDeleter.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofDeleter.java
@@ -29,9 +29,9 @@ public final class RequestProofDeleter {
   private Delete buildDelete(Result result) {
     String nonce = result.getText(AuditorInternalValues.REQUEST_PROOF_TABLE_NONCE_COLUMN_NAME);
     if (nonce == null) {
-      // The nonce column is the partition key of the request_proof table, so it can never be null
-      // for a real record. Reaching here means a programming bug, not bad input, so assert it.
-      throw new AssertionError(
+      // The nonce column is the partition key of the request_proof table, so it should never be
+      // null for a real record; guard against unexpected/corrupted data.
+      throw new IllegalStateException(
           "Partition key '"
               + AuditorInternalValues.REQUEST_PROOF_TABLE_NONCE_COLUMN_NAME
               + "' not found in the result");

--- a/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofDeleter.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofDeleter.java
@@ -29,10 +29,12 @@ public final class RequestProofDeleter {
   private Delete buildDelete(Result result) {
     String nonce = result.getText(AuditorInternalValues.REQUEST_PROOF_TABLE_NONCE_COLUMN_NAME);
     if (nonce == null) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Partition key '%s' not found in result",
-              AuditorInternalValues.REQUEST_PROOF_TABLE_NONCE_COLUMN_NAME));
+      // The nonce column is the partition key of the request_proof table, so it can never be null
+      // for a real record. Reaching here means a programming bug, not bad input, so assert it.
+      throw new AssertionError(
+          "Partition key '"
+              + AuditorInternalValues.REQUEST_PROOF_TABLE_NONCE_COLUMN_NAME
+              + "' not found in the result");
     }
     return Delete.newBuilder()
         .namespace(namespace)

--- a/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
@@ -95,12 +95,15 @@ class RequestProofCleanupOrchestratorTest {
 
   @Test
   void execute_corruptedTokenGiven_shouldThrowException() {
-    // Arrange: a token that cannot be decoded (malformed base64url/JSON or CRC mismatch).
+    // Arrange: a token whose payload is not valid JSON, so decoding fails.
     String corruptedToken = "aW52YWxpZC10b2tlbg"; // base64url("invalid-token")
     RequestProofCleanupOrchestrator orchestrator = newOrchestrator(NAMESPACE, corruptedToken);
 
     // Act & Assert
-    assertThatThrownBy(orchestrator::execute).isInstanceOf(CoordinatorStateDeleterException.class);
+    assertThatThrownBy(orchestrator::execute)
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.COMPLETION_TOKEN_DECODE_FAILED.buildCode());
   }
 
   @Test

--- a/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -92,13 +94,13 @@ class RequestProofCleanupOrchestratorTest {
   }
 
   @Test
-  void execute_corruptedTokenGiven_shouldThrowIllegalArgumentException() {
+  void execute_corruptedTokenGiven_shouldThrowException() {
     // Arrange: a token that cannot be decoded (malformed base64url/JSON or CRC mismatch).
     String corruptedToken = "aW52YWxpZC10b2tlbg"; // base64url("invalid-token")
     RequestProofCleanupOrchestrator orchestrator = newOrchestrator(NAMESPACE, corruptedToken);
 
     // Act & Assert
-    assertThatThrownBy(orchestrator::execute).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(orchestrator::execute).isInstanceOf(CoordinatorStateDeleterException.class);
   }
 
   @Test
@@ -109,8 +111,9 @@ class RequestProofCleanupOrchestratorTest {
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("wrong server type");
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.AUDITOR_TOKEN_WRONG_SERVER_TYPE.buildCode());
 
     // The boundary must not be persisted when the token is rejected.
     assertThat(new RequestProofCleanupStateManager(tempDir).load()).isNull();
@@ -190,14 +193,15 @@ class RequestProofCleanupOrchestratorTest {
   }
 
   @Test
-  void execute_noCheckpointAndMissingTokenGiven_shouldThrowIllegalArgumentException() {
+  void execute_noCheckpointAndMissingTokenGiven_shouldThrowException() {
     // Arrange
     RequestProofCleanupOrchestrator orchestrator = newOrchestrator(NAMESPACE, null);
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("The auditor completion token is required for the initial run");
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(
+            CoordinatorStateDeleterError.AUDITOR_COMPLETION_TOKEN_REQUIRED.buildCode());
   }
 
   @Test

--- a/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofDeleterTest.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofDeleterTest.java
@@ -54,7 +54,7 @@ class RequestProofDeleterTest {
   }
 
   @Test
-  void execute_partitionKeyMissingGiven_shouldThrowAssertionError() {
+  void execute_partitionKeyMissingGiven_shouldThrowException() {
     // Arrange: a record whose partition key column (nonce) is null.
     Result result = mock(Result.class);
     when(result.getText(NONCE)).thenReturn(null);
@@ -62,7 +62,7 @@ class RequestProofDeleterTest {
 
     // Act & Assert
     assertThatThrownBy(() -> deleter.execute(result))
-        .isInstanceOf(AssertionError.class)
+        .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("nonce");
   }
 

--- a/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofDeleterTest.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofDeleterTest.java
@@ -54,7 +54,7 @@ class RequestProofDeleterTest {
   }
 
   @Test
-  void execute_partitionKeyMissingGiven_shouldThrowIllegalArgumentException() {
+  void execute_partitionKeyMissingGiven_shouldThrowAssertionError() {
     // Arrange: a record whose partition key column (nonce) is null.
     Result result = mock(Result.class);
     when(result.getText(NONCE)).thenReturn(null);
@@ -62,7 +62,7 @@ class RequestProofDeleterTest {
 
     // Act & Assert
     assertThatThrownBy(() -> deleter.execute(result))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(AssertionError.class)
         .hasMessageContaining("nonce");
   }
 


### PR DESCRIPTION
## Description

This PR adds a structured error framework for the command layer, giving operator-facing failures stable codes and uniform messages while leaving purely internal guards as plain exceptions.

## Related issues and/or PRs

Depends on:

- #44 

## Changes made

- Add `ScalarDlToolsError` interface and `Category` enum as the shared error contract.
- Add `CoordinatorStateDeleterError` catalog covering the command layer's user and internal errors.
- Add `CoordinatorStateDeleterException` that carries the error `Category` and a formatted message.
- Add unit tests for the error catalog and exception.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A