### PR TITLE
Add validation to reject unsupported setups

### DIFF
--- a/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
@@ -13,6 +13,7 @@ import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;

--- a/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
@@ -13,6 +13,7 @@ import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -73,6 +74,7 @@ public final class AuditorFinalizeOrchestrator implements AutoCloseable {
    * @param checkpointDir root directory for checkpoint state
    * @return a new orchestrator instance
    * @throws IOException if the client configuration cannot be loaded
+   * @throws CoordinatorStateDeleterException if the configuration is not supported
    */
   // TODO: unify auditorProps and clientProps into a single Properties so callers only supply one
   //  configuration. We plan to make AuditorClient buildable without requiring additional client
@@ -84,6 +86,7 @@ public final class AuditorFinalizeOrchestrator implements AutoCloseable {
     AuditorClient auditorClient = null;
     try {
       DatabaseConfig databaseConfig = new DatabaseConfig(auditorProps);
+      StorageValidator.validate(databaseConfig);
       StorageFactory storageFactory = StorageFactory.create(auditorProps);
       admin = storageFactory.getStorageAdmin();
       storage = storageFactory.getStorage();

--- a/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestratorTest.java
+++ b/coordinator-state-deleter/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestratorTest.java
@@ -1,11 +1,14 @@
 package com.scalar.dl.tools.cleanup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,9 +19,12 @@ import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -26,9 +32,12 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 @SuppressWarnings("resource")
 class AuditorFinalizeOrchestratorTest {
@@ -71,6 +80,47 @@ class AuditorFinalizeOrchestratorTest {
   private AuditorFinalizeOrchestrator orchestrator() {
     return new AuditorFinalizeOrchestrator(
         admin, storage, auditorClient, scannerFactory, tempDir, NAMESPACE);
+  }
+
+  @Test
+  void create_nonCosmosStorageGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties auditorProps = new Properties();
+    auditorProps.setProperty(DatabaseConfig.STORAGE, "cassandra");
+
+    // Act & Assert
+    assertThatThrownBy(
+            () -> AuditorFinalizeOrchestrator.create(auditorProps, new Properties(), tempDir))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void create_cosmosStorageGiven_shouldNotThrow() {
+    // Arrange
+    Properties auditorProps = new Properties();
+    auditorProps.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    Properties clientProps = new Properties();
+    clientProps.setProperty("scalar.dl.client.mode", "client");
+    clientProps.setProperty("scalar.dl.client.entity.id", "test-entity");
+    clientProps.setProperty("scalar.dl.client.authentication.method", "hmac");
+    clientProps.setProperty("scalar.dl.client.entity.identity.hmac.secret_key", "test-secret");
+    clientProps.setProperty("scalar.dl.client.auditor.enabled", "true");
+
+    StorageFactory storageFactory = mock(StorageFactory.class);
+    when(storageFactory.getStorageAdmin()).thenReturn(mock(DistributedStorageAdmin.class));
+    when(storageFactory.getStorage()).thenReturn(mock(DistributedStorage.class));
+
+    try (MockedStatic<StorageFactory> storageFactoryStatic = mockStatic(StorageFactory.class);
+        MockedConstruction<AuditorClient> ignored = mockConstruction(AuditorClient.class)) {
+      storageFactoryStatic
+          .when(() -> StorageFactory.create(any(Properties.class)))
+          .thenReturn(storageFactory);
+
+      // Act & Assert
+      assertThatCode(() -> AuditorFinalizeOrchestrator.create(auditorProps, clientProps, tempDir))
+          .doesNotThrowAnyException();
+    }
   }
 
   @Test

--- a/coordinator-state-deleter/common/build.gradle
+++ b/coordinator-state-deleter/common/build.gradle
@@ -8,6 +8,8 @@ plugins {
 }
 
 dependencies {
+    api "com.scalar-labs:scalardb:${scalarDbVersion}"
+
     errorprone "com.google.errorprone:error_prone_core:${errorproneVersion}"
     spotbugs "com.github.spotbugs:spotbugs:${spotbugsVersion}"
     compileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugsVersion}"

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
@@ -65,6 +65,24 @@ public enum CoordinatorStateDeleterError implements ScalarDlToolsError {
       "The checkpoint directory path is invalid: %s.",
       "",
       "Provide a valid filesystem path for the checkpoint directory."),
+  UNSUPPORTED_STORAGE(
+      Category.USER_ERROR,
+      "010",
+      "The configured storage '%s' is not supported.",
+      "",
+      "Use a supported storage."),
+  JDBC_TRANSACTION_MANAGER_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "011",
+      "The JDBC transaction manager is not supported.",
+      "",
+      "This tool supports only the ScalarDB Consensus Commit transaction manager."),
+  GROUP_COMMIT_NOT_SUPPORTED(
+      Category.USER_ERROR,
+      "012",
+      "The Coordinator group commit is not supported.",
+      "",
+      "This tool supports only configurations with the Coordinator group commit disabled."),
 
   //
   // Errors for the internal error category

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/CoordinatorStateDeleterError.java
@@ -71,10 +71,10 @@ public enum CoordinatorStateDeleterError implements ScalarDlToolsError {
       "The configured storage '%s' is not supported.",
       "",
       "Use a supported storage."),
-  JDBC_TRANSACTION_MANAGER_NOT_SUPPORTED(
+  UNSUPPORTED_TRANSACTION_MANAGER(
       Category.USER_ERROR,
       "011",
-      "The JDBC transaction manager is not supported.",
+      "The configured transaction manager '%s' is not supported.",
       "",
       "This tool supports only the ScalarDB Consensus Commit transaction manager."),
   GROUP_COMMIT_NOT_SUPPORTED(

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
@@ -1,0 +1,41 @@
+package com.scalar.dl.tools.common;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+
+/**
+ * Validates that the ScalarDL configuration (including ScalarDB configuration) is supported by the
+ * tool.
+ */
+public final class LedgerConfigValidator {
+
+  private static final String JDBC_TRANSACTION_MANAGER = "jdbc";
+
+  private LedgerConfigValidator() {}
+
+  /**
+   * Throws if the configuration is not supported by the Ledger-side tools.
+   *
+   * @param databaseConfig the ScalarDB database configuration
+   * @throws CoordinatorStateDeleterException if the JDBC transaction manager is used, or if the
+   *     Coordinator group commit is enabled
+   */
+  public static void validate(DatabaseConfig databaseConfig) {
+    throwIfJdbcTransactionManager(databaseConfig);
+    throwIfGroupCommitEnabled(databaseConfig);
+  }
+
+  private static void throwIfJdbcTransactionManager(DatabaseConfig databaseConfig) {
+    if (JDBC_TRANSACTION_MANAGER.equalsIgnoreCase(databaseConfig.getTransactionManager())) {
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.JDBC_TRANSACTION_MANAGER_NOT_SUPPORTED);
+    }
+  }
+
+  private static void throwIfGroupCommitEnabled(DatabaseConfig databaseConfig) {
+    if (new ConsensusCommitConfig(databaseConfig).isCoordinatorGroupCommitEnabled()) {
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.GROUP_COMMIT_NOT_SUPPORTED);
+    }
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
@@ -2,6 +2,7 @@ package com.scalar.dl.tools.common;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import java.util.Objects;
 
 /**
  * Validates that the ScalarDL configuration (including ScalarDB configuration) is supported by the
@@ -21,6 +22,7 @@ public final class LedgerConfigValidator {
    *     Coordinator group commit is enabled
    */
   public static void validate(DatabaseConfig databaseConfig) {
+    Objects.requireNonNull(databaseConfig, "databaseConfig must not be null");
     throwIfJdbcTransactionManager(databaseConfig);
     throwIfGroupCommitEnabled(databaseConfig);
   }

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/LedgerConfigValidator.java
@@ -10,27 +10,26 @@ import java.util.Objects;
  */
 public final class LedgerConfigValidator {
 
-  private static final String JDBC_TRANSACTION_MANAGER = "jdbc";
-
   private LedgerConfigValidator() {}
 
   /**
    * Throws if the configuration is not supported by the Ledger-side tools.
    *
    * @param databaseConfig the ScalarDB database configuration
-   * @throws CoordinatorStateDeleterException if the JDBC transaction manager is used, or if the
-   *     Coordinator group commit is enabled
+   * @throws CoordinatorStateDeleterException if the transaction manager is not the Consensus Commit
+   *     transaction manager, or if the Coordinator group commit is enabled
    */
   public static void validate(DatabaseConfig databaseConfig) {
     Objects.requireNonNull(databaseConfig, "databaseConfig must not be null");
-    throwIfJdbcTransactionManager(databaseConfig);
+    throwIfNotConsensusCommitTransactionManager(databaseConfig);
     throwIfGroupCommitEnabled(databaseConfig);
   }
 
-  private static void throwIfJdbcTransactionManager(DatabaseConfig databaseConfig) {
-    if (JDBC_TRANSACTION_MANAGER.equalsIgnoreCase(databaseConfig.getTransactionManager())) {
+  private static void throwIfNotConsensusCommitTransactionManager(DatabaseConfig databaseConfig) {
+    String transactionManager = databaseConfig.getTransactionManager();
+    if (!ConsensusCommitConfig.TRANSACTION_MANAGER_NAME.equals(transactionManager)) {
       throw new CoordinatorStateDeleterException(
-          CoordinatorStateDeleterError.JDBC_TRANSACTION_MANAGER_NOT_SUPPORTED);
+          CoordinatorStateDeleterError.UNSUPPORTED_TRANSACTION_MANAGER, transactionManager);
     }
   }
 

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StorageValidator.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StorageValidator.java
@@ -1,0 +1,24 @@
+package com.scalar.dl.tools.common;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.cosmos.CosmosConfig;
+
+/** Validates that the configured ScalarDB storage is supported by the tool. */
+public final class StorageValidator {
+
+  private StorageValidator() {}
+
+  /**
+   * Throws if the configured storage is not supported. Only Cosmos DB is supported for now.
+   *
+   * @param databaseConfig the ScalarDB database configuration
+   * @throws CoordinatorStateDeleterException if the configured storage is not supported
+   */
+  public static void validate(DatabaseConfig databaseConfig) {
+    String storage = databaseConfig.getStorage();
+    if (!CosmosConfig.STORAGE_NAME.equals(storage)) {
+      throw new CoordinatorStateDeleterException(
+          CoordinatorStateDeleterError.UNSUPPORTED_STORAGE, storage);
+    }
+  }
+}

--- a/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StorageValidator.java
+++ b/coordinator-state-deleter/common/src/main/java/com/scalar/dl/tools/common/StorageValidator.java
@@ -2,6 +2,7 @@ package com.scalar.dl.tools.common;
 
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.storage.cosmos.CosmosConfig;
+import java.util.Objects;
 
 /** Validates that the configured ScalarDB storage is supported by the tool. */
 public final class StorageValidator {
@@ -15,6 +16,7 @@ public final class StorageValidator {
    * @throws CoordinatorStateDeleterException if the configured storage is not supported
    */
   public static void validate(DatabaseConfig databaseConfig) {
+    Objects.requireNonNull(databaseConfig, "databaseConfig must not be null");
     String storage = databaseConfig.getStorage();
     if (!CosmosConfig.STORAGE_NAME.equals(storage)) {
       throw new CoordinatorStateDeleterException(

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/LedgerConfigValidatorTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/LedgerConfigValidatorTest.java
@@ -35,7 +35,22 @@ class LedgerConfigValidatorTest {
     // Act Assert
     assertThatThrownBy(() -> LedgerConfigValidator.validate(databaseConfig))
         .isInstanceOf(CoordinatorStateDeleterException.class)
-        .hasMessageContaining("JDBC transaction manager")
+        .hasMessageContaining("jdbc")
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void
+      validate_singleCrudOperationTransactionManagerGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = baseProperties();
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "single-crud-operation");
+    DatabaseConfig databaseConfig = new DatabaseConfig(props);
+
+    // Act Assert
+    assertThatThrownBy(() -> LedgerConfigValidator.validate(databaseConfig))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("single-crud-operation")
         .hasMessageContaining("not supported");
   }
 

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/LedgerConfigValidatorTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/LedgerConfigValidatorTest.java
@@ -1,0 +1,55 @@
+package com.scalar.dl.tools.common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class LedgerConfigValidatorTest {
+
+  private static Properties baseProperties() {
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    return props;
+  }
+
+  @Test
+  void validate_consensusCommitWithoutGroupCommitGiven_shouldNotThrow() {
+    // Arrange
+    DatabaseConfig databaseConfig = new DatabaseConfig(baseProperties());
+
+    // Act Assert
+    assertThatCode(() -> LedgerConfigValidator.validate(databaseConfig)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void validate_jdbcTransactionManagerGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = baseProperties();
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
+    DatabaseConfig databaseConfig = new DatabaseConfig(props);
+
+    // Act Assert
+    assertThatThrownBy(() -> LedgerConfigValidator.validate(databaseConfig))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("JDBC transaction manager")
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void validate_groupCommitEnabledGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = baseProperties();
+    props.setProperty(ConsensusCommitConfig.COORDINATOR_GROUP_COMMIT_ENABLED, "true");
+    DatabaseConfig databaseConfig = new DatabaseConfig(props);
+
+    // Act Assert
+    assertThatThrownBy(() -> LedgerConfigValidator.validate(databaseConfig))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("group commit")
+        .hasMessageContaining("not supported");
+  }
+}

--- a/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/StorageValidatorTest.java
+++ b/coordinator-state-deleter/common/src/test/java/com/scalar/dl/tools/common/StorageValidatorTest.java
@@ -1,0 +1,41 @@
+package com.scalar.dl.tools.common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.config.DatabaseConfig;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class StorageValidatorTest {
+
+  private static DatabaseConfig databaseConfigWithStorage(String storage) {
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, storage);
+    return new DatabaseConfig(props);
+  }
+
+  @Test
+  void validate_cosmosStorageGiven_shouldNotThrow() {
+    // Arrange
+    DatabaseConfig databaseConfig = databaseConfigWithStorage("cosmos");
+
+    // Act Assert
+    assertThatCode(() -> StorageValidator.validate(databaseConfig)).doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"cassandra", "jdbc", "dynamo", "multi-storage"})
+  void validate_nonCosmosStorageGiven_shouldThrowCoordinatorStateDeleterException(String storage) {
+    // Arrange
+    DatabaseConfig databaseConfig = databaseConfigWithStorage(storage);
+
+    // Act Assert
+    assertThatThrownBy(() -> StorageValidator.validate(databaseConfig))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining(storage)
+        .hasMessageContaining("not supported");
+  }
+}

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
@@ -9,6 +9,8 @@ import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
+import com.scalar.dl.tools.common.LedgerConfigValidator;
+import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -87,6 +89,7 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
    * @param ledgerTokenString the Ledger completion token
    * @param auditorTokenString the Auditor completion token
    * @return a new orchestrator instance
+   * @throws CoordinatorStateDeleterException if the configuration is not supported
    */
   public static CoordinatorCleanupOrchestrator create(
       Properties props,
@@ -94,6 +97,8 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
       @Nullable String ledgerTokenString,
       @Nullable String auditorTokenString) {
     DatabaseConfig dbConfig = new DatabaseConfig(props);
+    StorageValidator.validate(dbConfig);
+    LedgerConfigValidator.validate(dbConfig);
     DistributedStorage storage = StorageFactory.create(props).getStorage();
     try {
       ResumableScannerFactory scannerFactory = new ResumableScannerFactory(dbConfig);

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -131,7 +131,8 @@ class CoordinatorCleanupOrchestratorTest {
                 CoordinatorCleanupOrchestrator.create(
                     props, tempDir, createLedgerToken(1000L), createAuditorToken(2000L)))
         .isInstanceOf(CoordinatorStateDeleterException.class)
-        .hasMessageContaining("JDBC transaction manager");
+        .hasMessageContaining("jdbc")
+        .hasMessageContaining("not supported");
   }
 
   @Test

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -1,15 +1,19 @@
 package com.scalar.dl.tools.cleanup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
@@ -18,6 +22,7 @@ import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
 
 @SuppressWarnings("resource")
 class CoordinatorCleanupOrchestratorTest {
@@ -95,6 +101,60 @@ class CoordinatorCleanupOrchestratorTest {
       String coordinatorNamespace, String ledgerToken, String auditorToken) {
     return new CoordinatorCleanupOrchestrator(
         storage, scannerFactory, tempDir, coordinatorNamespace, ledgerToken, auditorToken);
+  }
+
+  @Test
+  void create_nonCosmosStorageGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cassandra");
+
+    // Act & Assert
+    assertThatThrownBy(
+            () ->
+                CoordinatorCleanupOrchestrator.create(
+                    props, tempDir, createLedgerToken(1000L), createAuditorToken(2000L)))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void create_jdbcTransactionManagerGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
+
+    // Act & Assert
+    assertThatThrownBy(
+            () ->
+                CoordinatorCleanupOrchestrator.create(
+                    props, tempDir, createLedgerToken(1000L), createAuditorToken(2000L)))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("JDBC transaction manager");
+  }
+
+  @Test
+  void create_cosmosStorageGiven_shouldNotThrow() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+
+    StorageFactory storageFactory = mock(StorageFactory.class);
+    when(storageFactory.getStorage()).thenReturn(mock(DistributedStorage.class));
+
+    try (MockedStatic<StorageFactory> storageFactoryStatic = mockStatic(StorageFactory.class)) {
+      storageFactoryStatic
+          .when(() -> StorageFactory.create(any(Properties.class)))
+          .thenReturn(storageFactory);
+
+      // Act & Assert
+      assertThatCode(
+              () ->
+                  CoordinatorCleanupOrchestrator.create(
+                      props, tempDir, createLedgerToken(1000L), createAuditorToken(2000L)))
+          .doesNotThrowAnyException();
+    }
   }
 
   @Test

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
@@ -9,6 +9,9 @@ import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
+import com.scalar.dl.tools.common.LedgerConfigValidator;
+import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -59,12 +62,15 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
    * @param props the properties used by the ScalarDL Ledger
    * @param checkpointDir root directory for checkpoint state
    * @return a new orchestrator instance
-   * @throws IllegalStateException if the configured storage is not supported
+   * @throws CoordinatorStateDeleterException if the configured storage is not supported
    */
   public static LedgerFinalizeOrchestrator create(Properties props, Path checkpointDir) {
     DistributedStorageAdmin admin = null;
     DistributedTransactionManager txManager = null;
     try {
+      DatabaseConfig databaseConfig = new DatabaseConfig(props);
+      StorageValidator.validate(databaseConfig);
+      LedgerConfigValidator.validate(databaseConfig);
       StorageFactory storageFactory = StorageFactory.create(props);
       admin = storageFactory.getStorageAdmin();
       txManager = TransactionFactory.create(props).getTransactionManager();

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
@@ -74,8 +74,7 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
       StorageFactory storageFactory = StorageFactory.create(props);
       admin = storageFactory.getStorageAdmin();
       txManager = TransactionFactory.create(props).getTransactionManager();
-      ResumableScannerFactory scannerFactory =
-          new ResumableScannerFactory(new DatabaseConfig(props));
+      ResumableScannerFactory scannerFactory = new ResumableScannerFactory(databaseConfig);
       return new LedgerFinalizeOrchestrator(admin, txManager, scannerFactory, checkpointDir);
     } catch (Exception e) {
       if (txManager != null) {

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
@@ -62,7 +62,7 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
    * @param props the properties used by the ScalarDL Ledger
    * @param checkpointDir root directory for checkpoint state
    * @return a new orchestrator instance
-   * @throws CoordinatorStateDeleterException if the configured storage is not supported
+   * @throws CoordinatorStateDeleterException if the configuration is not supported
    */
   public static LedgerFinalizeOrchestrator create(Properties props, Path checkpointDir) {
     DistributedStorageAdmin admin = null;

--- a/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
@@ -1,11 +1,13 @@
 package com.scalar.dl.tools.cleanup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -13,7 +15,11 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorageAdmin;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
 import com.scalar.dl.tools.common.CompletionToken;
+import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -22,9 +28,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 
 @SuppressWarnings("resource")
 class LedgerFinalizeOrchestratorTest {
@@ -47,6 +55,59 @@ class LedgerFinalizeOrchestratorTest {
 
   private LedgerFinalizeOrchestrator newOrchestrator() {
     return new LedgerFinalizeOrchestrator(admin, txManager, scannerFactory, tempDir);
+  }
+
+  @Test
+  void create_nonCosmosStorageGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cassandra");
+
+    // Act & Assert
+    assertThatThrownBy(() -> LedgerFinalizeOrchestrator.create(props, tempDir))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void create_jdbcTransactionManagerGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "jdbc");
+
+    // Act & Assert
+    assertThatThrownBy(() -> LedgerFinalizeOrchestrator.create(props, tempDir))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("JDBC transaction manager");
+  }
+
+  @Test
+  void create_cosmosStorageGiven_shouldNotThrow() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+
+    StorageFactory storageFactory = mock(StorageFactory.class);
+    when(storageFactory.getStorageAdmin()).thenReturn(mock(DistributedStorageAdmin.class));
+    TransactionFactory transactionFactory = mock(TransactionFactory.class);
+    when(transactionFactory.getTransactionManager())
+        .thenReturn(mock(DistributedTransactionManager.class));
+
+    try (MockedStatic<StorageFactory> storageFactoryStatic = mockStatic(StorageFactory.class);
+        MockedStatic<TransactionFactory> transactionFactoryStatic =
+            mockStatic(TransactionFactory.class)) {
+      storageFactoryStatic
+          .when(() -> StorageFactory.create(any(Properties.class)))
+          .thenReturn(storageFactory);
+      transactionFactoryStatic
+          .when(() -> TransactionFactory.create(any(Properties.class)))
+          .thenReturn(transactionFactory);
+
+      // Act & Assert
+      assertThatCode(() -> LedgerFinalizeOrchestrator.create(props, tempDir))
+          .doesNotThrowAnyException();
+    }
   }
 
   @Test

--- a/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorTest.java
@@ -79,7 +79,8 @@ class LedgerFinalizeOrchestratorTest {
     // Act & Assert
     assertThatThrownBy(() -> LedgerFinalizeOrchestrator.create(props, tempDir))
         .isInstanceOf(CoordinatorStateDeleterException.class)
-        .hasMessageContaining("JDBC transaction manager");
+        .hasMessageContaining("jdbc")
+        .hasMessageContaining("not supported");
   }
 
   @Test

--- a/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestrator.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestrator.java
@@ -8,6 +8,7 @@ import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
+import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
@@ -91,10 +92,12 @@ public final class RequestProofCleanupOrchestrator implements AutoCloseable {
    * @param checkpointDir root directory for checkpoint state
    * @param auditorTokenString the Auditor completion token
    * @return a new orchestrator instance
+   * @throws CoordinatorStateDeleterException if the configuration is not supported
    */
   public static RequestProofCleanupOrchestrator create(
       Properties props, Path checkpointDir, @Nullable String auditorTokenString) {
     DatabaseConfig dbConfig = new DatabaseConfig(props);
+    StorageValidator.validate(dbConfig);
     DistributedStorage storage = StorageFactory.create(props).getStorage();
     try {
       ResumableScannerFactory scannerFactory = new ResumableScannerFactory(dbConfig);

--- a/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/request-proof-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RequestProofCleanupOrchestratorTest.java
@@ -1,15 +1,19 @@
 package com.scalar.dl.tools.cleanup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
@@ -18,9 +22,11 @@ import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
 import java.nio.file.Path;
+import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 
 @SuppressWarnings("resource")
 class RequestProofCleanupOrchestratorTest {
@@ -54,6 +60,41 @@ class RequestProofCleanupOrchestratorTest {
   private RequestProofCleanupOrchestrator newOrchestrator(String namespace, String auditorToken) {
     return new RequestProofCleanupOrchestrator(
         storage, scannerFactory, tempDir, namespace, auditorToken);
+  }
+
+  @Test
+  void create_nonCosmosStorageGiven_shouldThrowCoordinatorStateDeleterException() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cassandra");
+
+    // Act & Assert
+    assertThatThrownBy(
+            () -> RequestProofCleanupOrchestrator.create(props, tempDir, createAuditorToken(3000L)))
+        .isInstanceOf(CoordinatorStateDeleterException.class)
+        .hasMessageContaining("not supported");
+  }
+
+  @Test
+  void create_cosmosStorageGiven_shouldNotThrow() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+
+    StorageFactory storageFactory = mock(StorageFactory.class);
+    when(storageFactory.getStorage()).thenReturn(mock(DistributedStorage.class));
+
+    try (MockedStatic<StorageFactory> storageFactoryStatic = mockStatic(StorageFactory.class)) {
+      storageFactoryStatic
+          .when(() -> StorageFactory.create(any(Properties.class)))
+          .thenReturn(storageFactory);
+
+      // Act & Assert
+      assertThatCode(
+              () ->
+                  RequestProofCleanupOrchestrator.create(props, tempDir, createAuditorToken(3000L)))
+          .doesNotThrowAnyException();
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

The coordinator-state-deletion tools only support Cosmos DB and a standard Consensus Commit setup. This PR adds up-front configuration validation, so every command fails fast with a clear, coded error when the configuration is unsupported.

## Related issues and/or PRs

- #47 

## Changes made

- Add `StorageValidator` that rejects any storage other than Cosmos DB.
- Add `LedgerConfigValidator` that rejects the JDBC transaction manager and the group commit.
- Add unit tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A