### PR TITLE
Add E2E test infra setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,10 @@ on:
       - '.github/workflows/ci.yaml'
   workflow_dispatch:
 
+# Serialize every run that touches the shared Cosmos account.
+concurrency:
+  group: cosmos
+
 defaults:
   run:
     working-directory: coordinator-state-deleter

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,79 @@
+name: E2E
+
+# End-to-end test for coordinator-state-deleter. Currently brings ScalarDL Ledger +
+# Auditor up on minikube against a real Cosmos DB and runs the schema-loader; the CLI
+# test execution is added on top of this in follow-up changes. CI-only (needs secrets).
+#
+# Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
+
+on:
+  push: # TODO: remove after review — lets the branch be validated before a PR exists.
+    branches: [add-e2e-infra]
+    paths:
+      - 'coordinator-state-deleter/**'
+      - '.github/workflows/e2e.yaml'
+  pull_request:
+    paths:
+      - 'coordinator-state-deleter/**'
+      - '.github/workflows/e2e.yaml'
+  workflow_dispatch:
+    inputs:
+      scalardl_version:
+        description: 'ScalarDL image tag (ledger / auditor / schema-loader)'
+        default: '3.13.0'
+
+defaults:
+  run:
+    working-directory: coordinator-state-deleter
+
+concurrency:
+  group: e2e-cosmos
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SCALARDL_VERSION: ${{ github.event.inputs.scalardl_version || '3.13.0' }}
+      GHCR_USER: ${{ github.actor }}
+      COSMOS_URI: ${{ secrets.COSMOS_URI }}
+      COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+      CR_PAT: ${{ secrets.CR_PAT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up minikube
+        uses: medyagh/setup-minikube@latest
+        with:
+          cpus: '4'
+          memory: '8192'
+
+      - name: Deploy ScalarDL + load schema
+        run: ./ci/e2e/manage-cluster.sh deploy
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          for ns in ledger-e2e auditor-e2e; do
+            echo "===== namespace: $ns ====="
+            kubectl -n "$ns" get all -o wide
+            kubectl -n "$ns" get events --sort-by=.lastTimestamp
+            kubectl -n "$ns" describe pods
+            for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
+              echo "----- logs $p -----"
+              kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=300
+            done
+          done
+
+      - name: Drop Cosmos schema
+        if: always()
+        # Fatal on purpose: the shared Cosmos account must be left clean, so a failed
+        # drop fails the job to alert an operator (who then drops it manually).
+        run: ./ci/e2e/manage-cluster.sh drop-schema
+
+      - name: Tear down namespaces
+        if: always()
+        run: ./ci/e2e/manage-cluster.sh clean

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,31 +26,31 @@ defaults:
   run:
     working-directory: coordinator-state-deleter
 
+# Serialize every run that touches the shared Cosmos account.
 concurrency:
-  group: e2e-cosmos
-  cancel-in-progress: false
+  group: cosmos
 
 jobs:
   e2e:
     name: deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     env:
       SCALARDL_VERSION: ${{ github.event.inputs.scalardl_version || '3.13.0' }}
-      GHCR_USER: ${{ github.actor }}
-      COSMOS_URI: ${{ secrets.COSMOS_URI }}
-      COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
-      CR_PAT: ${{ secrets.CR_PAT }}
+      GHCR_USER: ${{ github.repository_owner }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           cpus: '4'
           memory: '8192'
 
       - name: Deploy ScalarDL + load schema
+        env:
+          COSMOS_URI: ${{ secrets.COSMOS_URI }}
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+          CR_PAT: ${{ secrets.CR_PAT }}
         run: ./ci/e2e/manage-cluster.sh deploy
 
       - name: Collect diagnostics on failure
@@ -70,6 +70,10 @@ jobs:
 
       - name: Drop Cosmos schema
         if: always()
+        env:
+          COSMOS_URI: ${{ secrets.COSMOS_URI }}
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+          CR_PAT: ${{ secrets.CR_PAT }}
         # Fatal on purpose: the shared Cosmos account must be left clean, so a failed
         # drop fails the job to alert an operator (who then drops it manually).
         run: ./ci/e2e/manage-cluster.sh drop-schema

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,11 +7,6 @@ name: E2E
 # Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
 on:
-  push: # TODO: remove after review — lets the branch be validated before a PR exists.
-    branches: [add-e2e-infra]
-    paths:
-      - 'coordinator-state-deleter/**'
-      - '.github/workflows/e2e.yaml'
   pull_request:
     paths:
       - 'coordinator-state-deleter/**'

--- a/coordinator-state-deleter/ci/e2e/auditor.yaml
+++ b/coordinator-state-deleter/ci/e2e/auditor.yaml
@@ -1,0 +1,134 @@
+# ScalarDL Auditor — deployed into ${AUDITOR_NS}, points at the Ledger in ${LEDGER_NS}.
+#
+# envsubst variables (see manage-cluster.sh):
+#   ${AUDITOR_NS}   k8s namespace for the auditor
+#   ${LEDGER_NS}    namespace where the ledger Service lives (for cross-ns DNS)
+#   ${AUDITOR_IMAGE} full image ref, e.g. ghcr.io/scalar-labs/scalardl-auditor:3.13.0
+#   ${COSMOS_URI}   Cosmos DB account URI
+#   ${COSMOS_KEY}   Cosmos DB primary key
+#
+# Auth is HMAC. SERVERS_HMAC_SECRET / HMAC_CIPHER_KEY are injected by
+# manage-cluster.sh (single source, shared with ledger.yaml) so the secret can't drift.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${AUDITOR_NS}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auditor-config
+  namespace: ${AUDITOR_NS}
+stringData:
+  auditor.properties: |
+    scalar.db.storage=cosmos
+    scalar.db.contact_points=${COSMOS_URI}
+    scalar.db.password=${COSMOS_KEY}
+
+    # Ports (gRPC / privileged / admin). Prometheus disabled.
+    scalar.dl.auditor.server.port=40051
+    scalar.dl.auditor.server.privileged_port=40052
+    scalar.dl.auditor.server.admin_port=40053
+    scalar.dl.auditor.server.prometheus_exporter_port=-1
+    scalar.dl.auditor.server.decommissioning_duration_secs=0
+
+    # Reach the Ledger via its cross-namespace ClusterIP DNS name.
+    scalar.dl.auditor.ledger.host=ledger.${LEDGER_NS}.svc.cluster.local
+    scalar.dl.auditor.ledger.port=50051
+    scalar.dl.auditor.ledger.privileged_port=50052
+
+    # HMAC authentication (clients and Ledger<->Auditor). The servers secret is the
+    # same value injected into ledger.yaml (single source in manage-cluster.sh).
+    scalar.dl.auditor.authentication.method=hmac
+    scalar.dl.auditor.authentication.hmac.cipher_key=${HMAC_CIPHER_KEY}
+    scalar.dl.auditor.servers.authentication.hmac.secret_key=${SERVERS_HMAC_SECRET}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scalardl-auditor
+  namespace: ${AUDITOR_NS}
+  labels:
+    app: scalardl-auditor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scalardl-auditor
+  template:
+    metadata:
+      labels:
+        app: scalardl-auditor
+    spec:
+      restartPolicy: Always
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: scalardl-auditor
+          image: ${AUDITOR_IMAGE}
+          # docker-entrypoint.sh execs "$@"; point --config at the mounted file.
+          args: ["./bin/scalar-auditor", "--config=/etc/scalardl/auditor.properties"]
+          ports:
+            - name: grpc
+              containerPort: 40051
+            - name: privileged
+              containerPort: 40052
+            - name: admin
+              containerPort: 40053
+          readinessProbe:
+            tcpSocket:
+              port: 40051
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 40051
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/scalardl
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: auditor-config
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: auditor
+  namespace: ${AUDITOR_NS}
+spec:
+  type: ClusterIP
+  selector:
+    app: scalardl-auditor
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 40051
+      targetPort: 40051
+    - name: privileged
+      protocol: TCP
+      port: 40052
+      targetPort: 40052
+    - name: admin
+      protocol: TCP
+      port: 40053
+      targetPort: 40053

--- a/coordinator-state-deleter/ci/e2e/ledger.yaml
+++ b/coordinator-state-deleter/ci/e2e/ledger.yaml
@@ -1,0 +1,136 @@
+# ScalarDL Ledger — deployed into ${LEDGER_NS}.
+#
+# envsubst variables (see manage-cluster.sh):
+#   ${LEDGER_NS}   k8s namespace for the ledger
+#   ${LEDGER_IMAGE} full image ref, e.g. ghcr.io/scalar-labs/scalardl-ledger:3.13.0
+#   ${COSMOS_URI}  Cosmos DB account URI
+#   ${COSMOS_KEY}  Cosmos DB primary key
+#
+# Auth is HMAC (not digital signature): the Ledger and Auditor authenticate each
+# other with a shared servers.authentication.hmac.secret_key, which avoids the
+# server-to-server certificate registration that digital-signature mode needs.
+# SERVERS_HMAC_SECRET / HMAC_CIPHER_KEY are injected by manage-cluster.sh (defined
+# once there) into both this and auditor.yaml, so the shared secret can't drift.
+# Disposable test values for this ephemeral cluster only; never reuse them.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${LEDGER_NS}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ledger-config
+  namespace: ${LEDGER_NS}
+stringData:
+  ledger.properties: |
+    scalar.db.storage=cosmos
+    scalar.db.contact_points=${COSMOS_URI}
+    scalar.db.password=${COSMOS_KEY}
+
+    # Ports (gRPC / privileged / admin). Prometheus disabled.
+    scalar.dl.ledger.server.port=50051
+    scalar.dl.ledger.server.privileged_port=50052
+    scalar.dl.ledger.server.admin_port=50053
+    scalar.dl.ledger.server.prometheus_exporter_port=-1
+    scalar.dl.ledger.server.decommissioning_duration_secs=0
+
+    # Auditor / proof mode. Required so the Auditor can pair with this Ledger.
+    scalar.dl.ledger.proof.enabled=true
+    scalar.dl.ledger.auditor.enabled=true
+
+    # HMAC authentication (clients and Ledger<->Auditor).
+    scalar.dl.ledger.authentication.method=hmac
+    scalar.dl.ledger.authentication.hmac.cipher_key=${HMAC_CIPHER_KEY}
+    scalar.dl.ledger.servers.authentication.hmac.secret_key=${SERVERS_HMAC_SECRET}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scalardl-ledger
+  namespace: ${LEDGER_NS}
+  labels:
+    app: scalardl-ledger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scalardl-ledger
+  template:
+    metadata:
+      labels:
+        app: scalardl-ledger
+    spec:
+      restartPolicy: Always
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: scalardl-ledger
+          image: ${LEDGER_IMAGE}
+          # docker-entrypoint.sh execs "$@", so pass the full server command and
+          # point --config at our mounted properties (overrides the baked default).
+          args: ["./bin/scalar-ledger", "--config=/etc/scalardl/ledger.properties"]
+          ports:
+            - name: grpc
+              containerPort: 50051
+            - name: privileged
+              containerPort: 50052
+            - name: admin
+              containerPort: 50053
+          readinessProbe:
+            tcpSocket:
+              port: 50051
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 50051
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/scalardl
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: ledger-config
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger
+  namespace: ${LEDGER_NS}
+spec:
+  type: ClusterIP
+  selector:
+    app: scalardl-ledger
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+      targetPort: 50051
+    - name: privileged
+      protocol: TCP
+      port: 50052
+      targetPort: 50052
+    - name: admin
+      protocol: TCP
+      port: 50053
+      targetPort: 50053

--- a/coordinator-state-deleter/ci/e2e/manage-cluster.sh
+++ b/coordinator-state-deleter/ci/e2e/manage-cluster.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Lifecycle helper for the E2E ScalarDL cluster on minikube against a real Cosmos DB.
+# Driven by .github/workflows/e2e.yaml. CI-only: needs network access, ghcr
+# credentials, and a Cosmos account.
+#
+# Modes:
+#   deploy       load the ScalarDB schema, deploy Ledger + Auditor, wait until healthy
+#   drop-schema  delete the ScalarDB schema (Cosmos cleanup)
+#   clean        delete the k8s namespaces
+#
+# Required environment (all modes except clean):
+#   COSMOS_URI   Cosmos DB account URI
+#   COSMOS_KEY   Cosmos DB primary key
+#   CR_PAT       ghcr Personal Access Token with read:packages
+#   GHCR_USER    ghcr username that owns CR_PAT
+#
+# Optional (default shown):
+#   SCALARDL_VERSION=3.13.0   # image tag for ledger, auditor, and schema-loader
+#
+# Usage:
+#   COSMOS_URI=... COSMOS_KEY=... CR_PAT=... GHCR_USER=... ./manage-cluster.sh deploy
+#   ./manage-cluster.sh drop-schema | clean
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# K8s namespaces.
+export LEDGER_NS="ledger-e2e"
+export AUDITOR_NS="auditor-e2e"
+
+# Container image names.
+: "${SCALARDL_VERSION:=3.13.0}"
+export LEDGER_IMAGE="ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}"
+export AUDITOR_IMAGE="ghcr.io/scalar-labs/scalardl-auditor:${SCALARDL_VERSION}"
+export SL_IMAGE="ghcr.io/scalar-labs/scalardl-schema-loader:${SCALARDL_VERSION}"
+
+# HMAC auth values.
+export SERVERS_HMAC_SECRET="e2e-servers-hmac-secret-disposable-0123456789"
+export HMAC_CIPHER_KEY="e2e-hmac-cipher-key-disposable-0123456789abcdef"
+
+# Schema-loader arguments. schema-loader.yaml is parametrized for both create (deploy)
+# and delete (drop-schema); these are the create defaults, overridden in drop-schema.
+export SL_JOB_SUFFIX=""
+export SL_LEDGER_ARGS='["--config", "/config/database.properties", "--coordinator"]'
+export SL_AUDITOR_ARGS='["--config", "/config/database.properties"]'
+
+# Give envsubst an explicit variable list so it substitutes ONLY these placeholders.
+# Without a list, envsubst expands EVERY $VAR in the manifests, which would wrongly
+# rewrite unrelated shell-style tokens (e.g. a literal $@ in a container command).
+SUBST_VARS='${LEDGER_NS} ${AUDITOR_NS} ${LEDGER_IMAGE} ${AUDITOR_IMAGE} ${SL_IMAGE} '
+SUBST_VARS+='${COSMOS_URI} ${COSMOS_KEY} ${SERVERS_HMAC_SECRET} ${HMAC_CIPHER_KEY} '
+SUBST_VARS+='${SL_JOB_SUFFIX} ${SL_LEDGER_ARGS} ${SL_AUDITOR_ARGS}'
+
+render() { envsubst "$SUBST_VARS" < "$HERE/$1"; }
+
+clean() {
+  echo "Deleting namespaces ${LEDGER_NS} and ${AUDITOR_NS} ..."
+  kubectl delete namespace "$LEDGER_NS" "$AUDITOR_NS" --ignore-not-found
+}
+
+if [[ "${1:-}" == "clean" ]]; then
+  clean
+  exit 0
+fi
+
+# Dump everything useful about a namespace's workloads, then fail.
+diag_and_die() {
+  local ns="$1" msg="$2"
+  echo "::error::${msg}"
+  echo "----- pods (${ns}) -----";           kubectl -n "$ns" get pods -o wide || true
+  echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
+  echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
+  echo "----- logs (${ns}) -----"
+  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
+    echo "### $p"
+    kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
+  done
+  exit 1
+}
+
+# Poll a Job for complete/failed (kubectl wait --for=complete hangs on failure),
+# printing diagnostics inline the moment it fails or times out.
+wait_for_job() {
+  local ns="$1" job="$2" timeout="${3:-300}" waited=0
+  while true; do
+    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q True; then
+      echo "job/$job complete"; return 0
+    fi
+    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q True; then
+      diag_and_die "$ns" "job/$job failed"
+    fi
+    if (( waited >= timeout )); then
+      diag_and_die "$ns" "job/$job did not complete within ${timeout}s"
+    fi
+    sleep 5; waited=$((waited + 5))
+  done
+}
+
+# Wait for a Deployment to become available, with inline diagnostics on timeout.
+wait_for_deploy() {
+  local ns="$1" dep="$2" timeout="${3:-300}"
+  if ! kubectl -n "$ns" wait --for=condition=available "deployment/$dep" --timeout="${timeout}s"; then
+    diag_and_die "$ns" "deployment/$dep did not become available within ${timeout}s"
+  fi
+}
+
+require_vars() {
+  for v in COSMOS_URI COSMOS_KEY CR_PAT GHCR_USER; do
+    if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
+  done
+}
+
+# Deploy schema + servers and block until both Deployments are available and pass a
+# gRPC health check. Leaves the servers running.
+deploy_all() {
+  echo "==> minikube start"
+  minikube status >/dev/null 2>&1 || minikube start --cpus=4 --memory=8192
+
+  echo "==> create namespaces"
+  kubectl create namespace "$LEDGER_NS" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create namespace "$AUDITOR_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+  echo "==> create ghcr pull secret in both namespaces"
+  for ns in "$LEDGER_NS" "$AUDITOR_NS"; do
+    kubectl create secret docker-registry ghcr-secret \
+      --docker-server=ghcr.io \
+      --docker-username="$GHCR_USER" \
+      --docker-password="$CR_PAT" \
+      --namespace="$ns" \
+      --dry-run=client -o yaml | kubectl apply -f -
+  done
+
+  echo "==> load schemas (ledger + coordinator, auditor)"
+  render schema-loader.yaml | kubectl apply -f -
+  wait_for_job "$LEDGER_NS"  schema-loader-ledger  300
+  wait_for_job "$AUDITOR_NS" schema-loader-auditor 300
+
+  echo "==> deploy ledger + auditor"
+  render ledger.yaml  | kubectl apply -f -
+  render auditor.yaml | kubectl apply -f -
+
+  echo "==> wait for deployments to become available"
+  wait_for_deploy "$LEDGER_NS"  scalardl-ledger  300
+  wait_for_deploy "$AUDITOR_NS" scalardl-auditor 300
+
+  echo "==> gRPC health checks"
+  kubectl -n "$LEDGER_NS" exec deploy/scalardl-ledger -- \
+    /usr/local/bin/grpc_health_probe -addr=:50051
+  kubectl -n "$AUDITOR_NS" exec deploy/scalardl-auditor -- \
+    /usr/local/bin/grpc_health_probe -addr=:40051
+
+  echo "==> confirm auditor is not crashlooping"
+  kubectl -n "$AUDITOR_NS" get pods -o wide
+  kubectl -n "$AUDITOR_NS" logs deploy/scalardl-auditor --tail=30 || true
+}
+
+require_vars
+
+case "${1:-}" in
+  deploy)
+    deploy_all
+    echo
+    echo "DEPLOY OK: servers Ready in $LEDGER_NS / $AUDITOR_NS."
+    ;;
+  drop-schema)
+    # If neither namespace exists, there is nothing to drop.
+    if ! kubectl get namespace "$LEDGER_NS" >/dev/null 2>&1 \
+        && ! kubectl get namespace "$AUDITOR_NS" >/dev/null 2>&1; then
+      echo "Namespaces ${LEDGER_NS}/${AUDITOR_NS} not found; nothing to drop."
+      exit 0
+    fi
+    # Delete the ScalarDB schema so the shared Cosmos account stays clean between runs,
+    # by re-rendering schema-loader.yaml with delete args + a distinct name suffix (a
+    # completed create Job can't be re-applied under the same name).
+    echo "==> delete ScalarDB schema (Cosmos cleanup)"
+    export SL_JOB_SUFFIX="-delete"
+    export SL_LEDGER_ARGS='["--config", "/config/database.properties", "-D", "--coordinator"]'
+    export SL_AUDITOR_ARGS='["--config", "/config/database.properties", "-D"]'
+    render schema-loader.yaml | kubectl apply -f -
+    wait_for_job "$LEDGER_NS"  schema-loader-ledger-delete  300
+    wait_for_job "$AUDITOR_NS" schema-loader-auditor-delete 300
+    echo
+    echo "DROP-SCHEMA OK"
+    ;;
+  *)
+    echo "usage: manage-cluster.sh [deploy|drop-schema|clean]" >&2
+    exit 1
+    ;;
+esac

--- a/coordinator-state-deleter/ci/e2e/manage-cluster.sh
+++ b/coordinator-state-deleter/ci/e2e/manage-cluster.sh
@@ -69,11 +69,11 @@ fi
 diag_and_die() {
   local ns="$1" msg="$2"
   echo "::error::${msg}"
-  echo "----- pods (${ns}) -----";           kubectl -n "$ns" get pods -o wide || true
+  echo "----- pods (${ns}) -----";            kubectl -n "$ns" get pods -o wide || true
   echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
   echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
   echo "----- logs (${ns}) -----"
-  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
+  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null || true); do
     echo "### $p"
     kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
   done
@@ -133,6 +133,9 @@ deploy_all() {
   done
 
   echo "==> load schemas (ledger + coordinator, auditor)"
+  # Jobs are immutable, so delete any leftovers first to keep re-runs idempotent.
+  kubectl -n "$LEDGER_NS"  delete job schema-loader-ledger  --ignore-not-found || true
+  kubectl -n "$AUDITOR_NS" delete job schema-loader-auditor --ignore-not-found || true
   render schema-loader.yaml | kubectl apply -f -
   wait_for_job "$LEDGER_NS"  schema-loader-ledger  300
   wait_for_job "$AUDITOR_NS" schema-loader-auditor 300
@@ -178,6 +181,9 @@ case "${1:-}" in
     export SL_JOB_SUFFIX="-delete"
     export SL_LEDGER_ARGS='["--config", "/config/database.properties", "-D", "--coordinator"]'
     export SL_AUDITOR_ARGS='["--config", "/config/database.properties", "-D"]'
+    # Delete leftovers first (Jobs are immutable) so drop-schema is re-runnable.
+    kubectl -n "$LEDGER_NS"  delete job schema-loader-ledger-delete  --ignore-not-found || true
+    kubectl -n "$AUDITOR_NS" delete job schema-loader-auditor-delete --ignore-not-found || true
     render schema-loader.yaml | kubectl apply -f -
     wait_for_job "$LEDGER_NS"  schema-loader-ledger-delete  300
     wait_for_job "$AUDITOR_NS" schema-loader-auditor-delete 300

--- a/coordinator-state-deleter/ci/e2e/manage-cluster.sh
+++ b/coordinator-state-deleter/ci/e2e/manage-cluster.sh
@@ -115,9 +115,6 @@ require_vars() {
 # Deploy schema + servers and block until both Deployments are available and pass a
 # gRPC health check. Leaves the servers running.
 deploy_all() {
-  echo "==> minikube start"
-  minikube status >/dev/null 2>&1 || minikube start --cpus=4 --memory=8192
-
   echo "==> create namespaces"
   kubectl create namespace "$LEDGER_NS" --dry-run=client -o yaml | kubectl apply -f -
   kubectl create namespace "$AUDITOR_NS" --dry-run=client -o yaml | kubectl apply -f -
@@ -153,10 +150,6 @@ deploy_all() {
     /usr/local/bin/grpc_health_probe -addr=:50051
   kubectl -n "$AUDITOR_NS" exec deploy/scalardl-auditor -- \
     /usr/local/bin/grpc_health_probe -addr=:40051
-
-  echo "==> confirm auditor is not crashlooping"
-  kubectl -n "$AUDITOR_NS" get pods -o wide
-  kubectl -n "$AUDITOR_NS" logs deploy/scalardl-auditor --tail=30 || true
 }
 
 require_vars

--- a/coordinator-state-deleter/ci/e2e/schema-loader.yaml
+++ b/coordinator-state-deleter/ci/e2e/schema-loader.yaml
@@ -1,0 +1,103 @@
+# Schema-loader Jobs — create the ScalarDB schema before deploying the servers,
+# and (with different args) delete it at teardown. Both modes share this one file;
+# manage-cluster.sh sets the envsubst variables per mode:
+#
+#   deploy      : SL_JOB_SUFFIX=""        SL_*_ARGS = create args
+#   drop-schema : SL_JOB_SUFFIX="-delete" SL_*_ARGS = create args + "-D"
+#
+# The suffix keeps the delete Jobs distinct from the create Jobs (a completed Job
+# is immutable and cannot be re-applied under the same name in the same namespace).
+#
+# envsubst variables (see manage-cluster.sh):
+#   ${LEDGER_NS}        Ledger namespace (must already exist)
+#   ${AUDITOR_NS}       Auditor namespace (must already exist)
+#   ${SL_IMAGE}         schema-loader image, e.g. ghcr.io/scalar-labs/scalardl-schema-loader:3.13.0
+#   ${COSMOS_URI}       Cosmos DB account URI
+#   ${COSMOS_KEY}       Cosmos DB primary key
+#   ${SL_JOB_SUFFIX}    "" (create) or "-delete"
+#   ${SL_LEDGER_ARGS}   ledger schema-loader CLI args (JSON array)
+#   ${SL_AUDITOR_ARGS}  auditor schema-loader CLI args (JSON array)
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: schema-loader-config
+  namespace: ${LEDGER_NS}
+stringData:
+  database.properties: |
+    scalar.db.storage=cosmos
+    scalar.db.contact_points=${COSMOS_URI}
+    scalar.db.password=${COSMOS_KEY}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: schema-loader-config
+  namespace: ${AUDITOR_NS}
+stringData:
+  database.properties: |
+    scalar.db.storage=cosmos
+    scalar.db.contact_points=${COSMOS_URI}
+    scalar.db.password=${COSMOS_KEY}
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: schema-loader-ledger${SL_JOB_SUFFIX}
+  namespace: ${LEDGER_NS}
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: schema-loader-ledger
+          image: ${SL_IMAGE}
+          args: ${SL_LEDGER_ARGS}
+          env:
+            - name: SCHEMA_TYPE
+              value: "ledger"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: schema-loader-config
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: schema-loader-auditor${SL_JOB_SUFFIX}
+  namespace: ${AUDITOR_NS}
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: schema-loader-auditor
+          image: ${SL_IMAGE}
+          args: ${SL_AUDITOR_ARGS}
+          env:
+            - name: SCHEMA_TYPE
+              value: "auditor"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: schema-loader-config


### PR DESCRIPTION
## Description

This PR adds an infra setup for an E2E test that exercises the tool against real ScalarDL servers.

## Related issues and/or PRs

N/A

## Changes made

- Add `e2e.yaml` workflow that provisions minikube, deploys ScalarDL against Cosmos DB, and tears everything down.
- Add `ci/e2e/manage-cluster.sh` with deploy / drop-schema / clean modes to manage the cluster lifecycle.
- Add envsubst-templated Kubernetes manifests for the Ledger, Auditor, and schema-loader.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The test itself will be added later.

## Release notes

N/A