### PR TITLE
Add population part for E2E test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,9 @@
 name: E2E
 
-# End-to-end test for coordinator-state-deleter. Currently brings ScalarDL Ledger +
-# Auditor up on minikube against a real Cosmos DB and runs the schema-loader; the CLI
-# test execution is added on top of this in follow-up changes. CI-only (needs secrets).
+# End-to-end test for coordinator-state-deleter. Brings ScalarDL Ledger + Auditor up on
+# minikube against a real Cosmos DB, loads the schema, and populates committed + stranded
+# auditor-mode "old data" with the ScalarDL HashStore CLI; the coordinator-state-deleter
+# verification is added on top of this in a follow-up. CI-only (needs secrets).
 #
 # Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
@@ -14,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       scalardl_version:
-        description: 'ScalarDL image tag (ledger / auditor / schema-loader)'
+        description: 'ScalarDL image tag (ledger / auditor / schema-loader) and HashStore CLI version'
         default: '3.13.0'
 
 defaults:
@@ -27,13 +28,31 @@ concurrency:
 
 jobs:
   e2e:
-    name: deploy
+    name: populate
     runs-on: ubuntu-latest
     env:
       SCALARDL_VERSION: ${{ github.event.inputs.scalardl_version || '3.13.0' }}
       GHCR_USER: ${{ github.repository_owner }}
+      # Records generated per category (committed / stranded write / stranded read).
+      RECORD_COUNT: 5
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+
+      - name: Download ScalarDL HashStore CLI
+        run: |
+          set -euo pipefail
+          url="https://github.com/scalar-labs/scalardl/releases/download/v${SCALARDL_VERSION}/scalardl-hashstore-java-client-sdk-${SCALARDL_VERSION}.zip"
+          curl -sSfL -o "$RUNNER_TEMP/hashstore.zip" "$url"
+          unzip -q "$RUNNER_TEMP/hashstore.zip" -d "$RUNNER_TEMP/hashstore"
+          bin="$RUNNER_TEMP/hashstore/scalardl-hashstore-java-client-sdk-${SCALARDL_VERSION}/bin/scalardl-hashstore"
+          chmod +x "$bin"
+          echo "CLIENT=$bin" >> "$GITHUB_ENV"
 
       - name: Set up minikube
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
@@ -47,6 +66,71 @@ jobs:
           COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
           CR_PAT: ${{ secrets.CR_PAT }}
         run: ./ci/e2e/manage-cluster.sh deploy
+
+      - name: Populate committed data
+        run: |
+          set -euo pipefail
+          source ci/e2e/port-forward.sh
+          pf_reset
+          pf_start ledger-e2e  svc/ledger  50051:50051 50052:50052
+          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
+          pf_wait 50051 50052 40051 40052
+          props="ci/e2e/client.properties"
+          # Register the client identity + the generic object contracts on both servers.
+          "$CLIENT" bootstrap --properties "$props"
+          # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)
+          # produces asset / request_proof / coordinator.state / released asset_lock records.
+          for i in $(seq 0 $((RECORD_COUNT - 1))); do
+            id="e2e-asset-$i"
+            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+            "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"
+          done
+
+      - name: Generate stranded locks (Ledger down)
+        run: |
+          set -euo pipefail
+          source ci/e2e/port-forward.sh
+          pf_reset
+          ./ci/e2e/manage-cluster.sh stop-ledger
+          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
+          pf_wait 40051 40052
+          props="ci/e2e/client.properties"
+          # Every op MUST fail (Ledger down): the Auditor is left holding the lock. Fail the job if
+          # any unexpectedly succeeds. put-object leaves a WRITE lock on a fresh id; get-object leaves
+          # a READ lock on an already-committed id.
+          for i in $(seq 0 $((RECORD_COUNT - 1))); do
+            id="e2e-stranded-$i"
+            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+            if "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
+              echo "::error::stranded put-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
+            fi
+          done
+          for i in $(seq 0 $((RECORD_COUNT - 1))); do
+            id="e2e-asset-$i"
+            if "$CLIENT" get-object --properties "$props" --object-id "$id"; then
+              echo "::error::stranded get-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
+            fi
+          done
+          echo "Waiting 16s for the held locks to pass the 15s valid period ..."
+          sleep 16
+
+      # Record what was populated, for the assertion part (added in a follow-up) and for inspection.
+      - name: Write populated-assets metadata
+        run: |
+          jq -n --argjson n "$RECORD_COUNT" '{
+            entityId: "e2e-client",
+            committedAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
+            strandedAssetIds: [range(0; $n) | "e2e-stranded-\(.)"],
+            strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"]
+          }' > "$RUNNER_TEMP/populated-assets.json"
+
+      - name: Upload populated-assets
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-populated-assets
+          path: ${{ runner.temp }}/populated-assets.json
+          if-no-files-found: warn
 
       - name: Collect diagnostics on failure
         if: failure()
@@ -62,6 +146,8 @@ jobs:
               kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=300
             done
           done
+          echo "===== port-forward logs ====="
+          cat /tmp/pf-*.log 2>/dev/null || true
 
       - name: Drop Cosmos schema
         if: always()

--- a/coordinator-state-deleter/ci/e2e/client.properties
+++ b/coordinator-state-deleter/ci/e2e/client.properties
@@ -1,0 +1,6 @@
+scalar.dl.client.server.host=127.0.0.1
+scalar.dl.client.auditor.enabled=true
+scalar.dl.client.auditor.host=127.0.0.1
+scalar.dl.client.authentication.method=hmac
+scalar.dl.client.entity.id=e2e-client
+scalar.dl.client.entity.identity.hmac.secret_key=e2e-client-hmac-secret-disposable-0123456789

--- a/coordinator-state-deleter/ci/e2e/manage-cluster.sh
+++ b/coordinator-state-deleter/ci/e2e/manage-cluster.sh
@@ -67,13 +67,19 @@ clean() {
   kubectl delete namespace "$LEDGER_NS" "$AUDITOR_NS" --ignore-not-found
 }
 
-# Scale the Ledger to 0 and wait for its pod to disappear. With the Ledger down, the next
-# auditor-mode put/get cannot commit, so the Auditor is left holding the lock — used to
-# seed stranded locks for the recovery test.
+# Scale the Ledger to 0 and wait for its pod to disappear.
 stop_ledger() {
   echo "==> scale down the Ledger"
   kubectl -n "$LEDGER_NS" scale deployment/scalardl-ledger --replicas=0
-  kubectl -n "$LEDGER_NS" wait --for=delete pod -l app=scalardl-ledger --timeout=120s
+  # `kubectl wait --for=delete` errors with "no matching resources found" if the pod is already
+  # gone — the Ledger was already scaled down, or the pod was deleted in the window between the
+  # scale and the wait. Treat a failed wait as success unless a pod actually still remains.
+  if ! kubectl -n "$LEDGER_NS" wait --for=delete pod -l app=scalardl-ledger --timeout=120s 2>/dev/null; then
+    if [[ -n "$(kubectl -n "$LEDGER_NS" get pods -l app=scalardl-ledger -o name)" ]]; then
+      echo "::error::Ledger pod did not terminate within 120s"
+      exit 1
+    fi
+  fi
 }
 
 # Dump everything useful about a namespace's workloads, then fail.

--- a/coordinator-state-deleter/ci/e2e/manage-cluster.sh
+++ b/coordinator-state-deleter/ci/e2e/manage-cluster.sh
@@ -6,10 +6,11 @@
 #
 # Modes:
 #   deploy       load the ScalarDB schema, deploy Ledger + Auditor, wait until healthy
+#   stop-ledger  scale the Ledger to 0 and wait for its pod to be deleted
 #   drop-schema  delete the ScalarDB schema (Cosmos cleanup)
 #   clean        delete the k8s namespaces
 #
-# Required environment (all modes except clean):
+# Required environment (deploy and drop-schema only):
 #   COSMOS_URI   Cosmos DB account URI
 #   COSMOS_KEY   Cosmos DB primary key
 #   CR_PAT       ghcr Personal Access Token with read:packages
@@ -20,7 +21,7 @@
 #
 # Usage:
 #   COSMOS_URI=... COSMOS_KEY=... CR_PAT=... GHCR_USER=... ./manage-cluster.sh deploy
-#   ./manage-cluster.sh drop-schema | clean
+#   ./manage-cluster.sh stop-ledger | drop-schema | clean
 
 set -euo pipefail
 
@@ -55,15 +56,25 @@ SUBST_VARS+='${SL_JOB_SUFFIX} ${SL_LEDGER_ARGS} ${SL_AUDITOR_ARGS}'
 
 render() { envsubst "$SUBST_VARS" < "$HERE/$1"; }
 
+require_vars() {
+  for v in COSMOS_URI COSMOS_KEY CR_PAT GHCR_USER; do
+    if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
+  done
+}
+
 clean() {
   echo "Deleting namespaces ${LEDGER_NS} and ${AUDITOR_NS} ..."
   kubectl delete namespace "$LEDGER_NS" "$AUDITOR_NS" --ignore-not-found
 }
 
-if [[ "${1:-}" == "clean" ]]; then
-  clean
-  exit 0
-fi
+# Scale the Ledger to 0 and wait for its pod to disappear. With the Ledger down, the next
+# auditor-mode put/get cannot commit, so the Auditor is left holding the lock — used to
+# seed stranded locks for the recovery test.
+stop_ledger() {
+  echo "==> scale down the Ledger"
+  kubectl -n "$LEDGER_NS" scale deployment/scalardl-ledger --replicas=0
+  kubectl -n "$LEDGER_NS" wait --for=delete pod -l app=scalardl-ledger --timeout=120s
+}
 
 # Dump everything useful about a namespace's workloads, then fail.
 diag_and_die() {
@@ -106,12 +117,6 @@ wait_for_deploy() {
   fi
 }
 
-require_vars() {
-  for v in COSMOS_URI COSMOS_KEY CR_PAT GHCR_USER; do
-    if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
-  done
-}
-
 # Deploy schema + servers and block until both Deployments are available and pass a
 # gRPC health check. Leaves the servers running.
 deploy_all() {
@@ -152,15 +157,20 @@ deploy_all() {
     /usr/local/bin/grpc_health_probe -addr=:40051
 }
 
-require_vars
-
 case "${1:-}" in
   deploy)
+    require_vars
     deploy_all
     echo
     echo "DEPLOY OK: servers Ready in $LEDGER_NS / $AUDITOR_NS."
     ;;
+  stop-ledger)
+    stop_ledger
+    echo
+    echo "STOP-LEDGER OK: $LEDGER_NS/scalardl-ledger scaled to 0."
+    ;;
   drop-schema)
+    require_vars
     # If neither namespace exists, there is nothing to drop.
     if ! kubectl get namespace "$LEDGER_NS" >/dev/null 2>&1 \
         && ! kubectl get namespace "$AUDITOR_NS" >/dev/null 2>&1; then
@@ -183,8 +193,11 @@ case "${1:-}" in
     echo
     echo "DROP-SCHEMA OK"
     ;;
+  clean)
+    clean
+    ;;
   *)
-    echo "usage: manage-cluster.sh [deploy|drop-schema|clean]" >&2
+    echo "usage: manage-cluster.sh [deploy|stop-ledger|drop-schema|clean]" >&2
     exit 1
     ;;
 esac

--- a/coordinator-state-deleter/ci/e2e/port-forward.sh
+++ b/coordinator-state-deleter/ci/e2e/port-forward.sh
@@ -13,7 +13,7 @@ pf_check_tcp() { timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; 
 
 # Kill any leftover kubectl port-forwards.
 pf_reset() {
-  pkill -f 'kubectl.*port-forward' 2>/dev/null || true
+  pkill -f 'kubectl.*port-forward.*(ledger|auditor)' 2>/dev/null || true
   sleep 2
 }
 
@@ -41,6 +41,8 @@ pf_wait() {
     done
     [ -n "$ok" ] || {
       echo "::error::localhost:$p not reachable through port-forward"
+      echo "=== port-forward logs ==="
+      tail -n 50 /tmp/pf-*.log 2>/dev/null || true
       return 1
     }
   done

--- a/coordinator-state-deleter/ci/e2e/port-forward.sh
+++ b/coordinator-state-deleter/ci/e2e/port-forward.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Shared kubectl port-forward helpers for the E2E test cluster. Usage:
+#
+#   source ci/e2e/port-forward.sh
+#   pf_reset # kill leftovers from prior steps
+#   pf_start "$LNS" svc/ledger  50051:50051 50052:50052
+#   pf_start "$ANS" svc/auditor 40051:40051 40052:40052
+#   pf_wait 50051 50052 40051 40052 # block until reachable
+
+# TCP connect check via a bash builtin.
+pf_check_tcp() { timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; }
+
+# Kill any leftover kubectl port-forwards.
+pf_reset() {
+  pkill -f 'kubectl.*port-forward' 2>/dev/null || true
+  sleep 2
+}
+
+# Start a background port-forward: pf_start <ns> <target> <local:remote>...
+# Logs to /tmp/pf-<first-local-port>.log so failure diagnostics can collect it.
+pf_start() {
+  local ns="$1" target="$2"
+  shift 2
+  local first_local="${1%%:*}"
+  kubectl -n "$ns" port-forward "$target" "$@" >"/tmp/pf-${first_local}.log" 2>&1 &
+}
+
+# Block until each given local port accepts a TCP connection (~30s each), else fail.
+# Returns non-zero on timeout so `set -e` callers abort.
+pf_wait() {
+  local p i ok
+  for p in "$@"; do
+    ok=""
+    for i in $(seq 1 30); do
+      if pf_check_tcp "$p"; then
+        ok=1
+        break
+      fi
+      sleep 1
+    done
+    [ -n "$ok" ] || {
+      echo "::error::localhost:$p not reachable through port-forward"
+      return 1
+    }
+  done
+}


### PR DESCRIPTION
## Description

The base E2E infrastructure brings the ScalarDL servers up but generates no data. This PR adds the "old data" population layer

## Related issues and/or PRs

N/A

## Changes made

- Add a populate stage to the E2E workflow.
- Add ci/e2e/port-forward.sh — shared kubectl port-forward helpers.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The test itself will be added later.

## Release notes

N/A