### PR TITLE
Follow ScalarDB rename

### DIFF
--- a/coordinator-state-deleter/coordinator-state-cleanup/src/integration-test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorIntegrationTestBase.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/integration-test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorIntegrationTestBase.java
@@ -17,7 +17,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.transaction.consensuscommit.Attribute;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import java.nio.file.Path;
@@ -80,8 +80,8 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
       throws Exception {
     Put put =
         Put.newBuilder()
-            .namespace(Coordinator.NAMESPACE)
-            .table(Coordinator.TABLE)
+            .namespace(CoordinatorStateAccessor.NAMESPACE)
+            .table(CoordinatorStateAccessor.TABLE)
             .partitionKey(Key.ofText(Attribute.ID, txId))
             .intValue(Attribute.STATE, state.get())
             .bigIntValue(Attribute.CREATED_AT, createdAt)
@@ -127,8 +127,8 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
   private void assertCoordinatorRecordPresent(String txId) throws Exception {
     Get get =
         Get.newBuilder()
-            .namespace(Coordinator.NAMESPACE)
-            .table(Coordinator.TABLE)
+            .namespace(CoordinatorStateAccessor.NAMESPACE)
+            .table(CoordinatorStateAccessor.TABLE)
             .partitionKey(Key.ofText(Attribute.ID, txId))
             .build();
     Optional<Result> result = storage.get(get);
@@ -138,8 +138,8 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
   private void assertCoordinatorRecordAbsent(String txId) throws Exception {
     Get get =
         Get.newBuilder()
-            .namespace(Coordinator.NAMESPACE)
-            .table(Coordinator.TABLE)
+            .namespace(CoordinatorStateAccessor.NAMESPACE)
+            .table(CoordinatorStateAccessor.TABLE)
             .partitionKey(Key.ofText(Attribute.ID, txId))
             .build();
     Optional<Result> result = storage.get(get);
@@ -190,7 +190,7 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
             storage,
             scannerFactory,
             checkpointDir,
-            Coordinator.NAMESPACE,
+            CoordinatorStateAccessor.NAMESPACE,
             ledgerToken,
             auditorToken);
     orchestrator.execute();
@@ -220,7 +220,7 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
             storage,
             scannerFactory,
             checkpointDir,
-            Coordinator.NAMESPACE,
+            CoordinatorStateAccessor.NAMESPACE,
             ledgerToken,
             auditorToken);
     orchestrator.execute();
@@ -244,7 +244,7 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
     // Act
     CoordinatorCleanupOrchestrator orchestrator =
         new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, checkpointDir, Coordinator.NAMESPACE, null, null);
+            storage, scannerFactory, checkpointDir, CoordinatorStateAccessor.NAMESPACE, null, null);
     orchestrator.execute();
 
     // Assert
@@ -268,13 +268,13 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
             storage,
             scannerFactory,
             checkpointDir,
-            Coordinator.NAMESPACE,
+            CoordinatorStateAccessor.NAMESPACE,
             ledgerToken,
             auditorToken)
         .execute();
     // The second run against the completed checkpoint must be a safe no-op
     new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, checkpointDir, Coordinator.NAMESPACE, null, null)
+            storage, scannerFactory, checkpointDir, CoordinatorStateAccessor.NAMESPACE, null, null)
         .execute();
 
     // Assert
@@ -292,7 +292,8 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
     String auditorToken = createAuditorToken(DELETABLE_BEFORE_MS);
 
     // A spy that throws on the 3rd call, simulating a crash partway through the scan.
-    RecordDeleter interruptingDeleter = spy(new RecordDeleter(storage, Coordinator.NAMESPACE));
+    RecordDeleter interruptingDeleter =
+        spy(new RecordDeleter(storage, CoordinatorStateAccessor.NAMESPACE));
     AtomicLong deleteCount = new AtomicLong();
     doAnswer(
             invocation -> {
@@ -310,7 +311,7 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
             storage,
             scannerFactory,
             checkpointDir,
-            Coordinator.NAMESPACE,
+            CoordinatorStateAccessor.NAMESPACE,
             ledgerToken,
             auditorToken,
             interruptingDeleter);
@@ -326,7 +327,7 @@ public abstract class CoordinatorCleanupOrchestratorIntegrationTestBase {
 
     // Act 2: re-run against the same checkpoint without tokens, resuming the previous run.
     new CoordinatorCleanupOrchestrator(
-            storage, scannerFactory, checkpointDir, Coordinator.NAMESPACE, null, null)
+            storage, scannerFactory, checkpointDir, CoordinatorStateAccessor.NAMESPACE, null, null)
         .execute();
 
     // Assert: exactly the deletable records are gone, the rest remain, and the run completed.

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestrator.java
@@ -5,7 +5,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
@@ -119,7 +119,7 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
   private static String resolveCoordinatorNamespace(DatabaseConfig dbConfig) {
     return new ConsensusCommitConfig(dbConfig)
         .getCoordinatorNamespace()
-        .orElse(Coordinator.NAMESPACE);
+        .orElse(CoordinatorStateAccessor.NAMESPACE);
   }
 
   /**
@@ -228,7 +228,8 @@ public final class CoordinatorCleanupOrchestrator implements AutoCloseable {
             new RecordDeletionChecker(deletableBeforeMs), recordDeleter);
 
     try (ResumableScanner scanner = scannerFactory.create(scanCheckpointDir)) {
-      ScanResult scanResult = scanner.scan(coordinatorNamespace, Coordinator.TABLE, handler);
+      ScanResult scanResult =
+          scanner.scan(coordinatorNamespace, CoordinatorStateAccessor.TABLE, handler);
 
       // The deletion count is per run (command execution) only. Tracking a cumulative total across
       // runs would require persisting it on every deletion, so we report only what this run did.

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/main/java/com/scalar/dl/tools/cleanup/RecordDeleter.java
@@ -4,7 +4,7 @@ import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Result;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -35,7 +35,7 @@ public final class RecordDeleter {
 
     return Delete.newBuilder()
         .namespace(coordinatorNamespace)
-        .table(Coordinator.TABLE)
+        .table(CoordinatorStateAccessor.TABLE)
         .partitionKey(partitionKey)
         .build();
   }

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/CoordinatorCleanupOrchestratorTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterError;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
@@ -164,13 +164,14 @@ class CoordinatorCleanupOrchestratorTest {
     String ledgerToken = createLedgerToken(2000L);
     String auditorToken = createAuditorToken(3000L);
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(CoordinatorStateAccessor.NAMESPACE, ledgerToken, auditorToken);
 
     // Act
     orchestrator.execute();
 
     // Assert
-    verify(scanner).scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any());
+    verify(scanner)
+        .scan(eq(CoordinatorStateAccessor.NAMESPACE), eq(CoordinatorStateAccessor.TABLE), any());
 
     // The boundary (earlier of the two token timestamps) is observable via the persisted state.
     CoordinatorCleanupState state = new CoordinatorCleanupStateManager(tempDir).load();
@@ -188,7 +189,7 @@ class CoordinatorCleanupOrchestratorTest {
     stateManager.persist(completedState);
 
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, null, null);
+        newOrchestrator(CoordinatorStateAccessor.NAMESPACE, null, null);
 
     // Act
     orchestrator.execute();
@@ -206,7 +207,7 @@ class CoordinatorCleanupOrchestratorTest {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
         newOrchestrator(
-            Coordinator.NAMESPACE,
+            CoordinatorStateAccessor.NAMESPACE,
             createLedgerToken(ledgerTimestamp),
             createAuditorToken(auditorTimestamp));
 
@@ -225,7 +226,7 @@ class CoordinatorCleanupOrchestratorTest {
       String ledgerToken, String auditorToken, CoordinatorStateDeleterError expected) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(CoordinatorStateAccessor.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
@@ -236,10 +237,14 @@ class CoordinatorCleanupOrchestratorTest {
   @Test
   void execute_scanFailureGiven_shouldPropagateException() throws Exception {
     // Arrange
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
+    when(scanner.scan(
+            eq(CoordinatorStateAccessor.NAMESPACE), eq(CoordinatorStateAccessor.TABLE), any()))
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
+        newOrchestrator(
+            CoordinatorStateAccessor.NAMESPACE,
+            createLedgerToken(2000L),
+            createAuditorToken(3000L));
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
@@ -251,10 +256,14 @@ class CoordinatorCleanupOrchestratorTest {
   @Test
   void execute_scanFailureGiven_shouldNotMarkCompleted() throws Exception {
     // Arrange
-    when(scanner.scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any()))
+    when(scanner.scan(
+            eq(CoordinatorStateAccessor.NAMESPACE), eq(CoordinatorStateAccessor.TABLE), any()))
         .thenThrow(new RuntimeException("Cosmos DB unavailable"));
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
+        newOrchestrator(
+            CoordinatorStateAccessor.NAMESPACE,
+            createLedgerToken(2000L),
+            createAuditorToken(3000L));
 
     // Act
     assertThatThrownBy(orchestrator::execute).isInstanceOf(RuntimeException.class);
@@ -274,14 +283,15 @@ class CoordinatorCleanupOrchestratorTest {
     stateManager.persist(new CoordinatorCleanupState(500L));
 
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, null, null);
+        newOrchestrator(CoordinatorStateAccessor.NAMESPACE, null, null);
 
     // Act
     orchestrator.execute();
 
     // Assert
     // The persisted boundary is reused (not recomputed) and the scan runs
-    verify(scanner).scan(eq(Coordinator.NAMESPACE), eq(Coordinator.TABLE), any());
+    verify(scanner)
+        .scan(eq(CoordinatorStateAccessor.NAMESPACE), eq(CoordinatorStateAccessor.TABLE), any());
     CoordinatorCleanupState state = stateManager.load();
     assertThat(state).isNotNull();
     assertThat(state.getDeletableBeforeMs()).isEqualTo(500L);
@@ -295,7 +305,10 @@ class CoordinatorCleanupOrchestratorTest {
 
     // Tokens that would compute a different boundary (2000) if they were not ignored
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(2000L), createAuditorToken(3000L));
+        newOrchestrator(
+            CoordinatorStateAccessor.NAMESPACE,
+            createLedgerToken(2000L),
+            createAuditorToken(3000L));
 
     // Act
     orchestrator.execute();
@@ -313,7 +326,7 @@ class CoordinatorCleanupOrchestratorTest {
       String ledgerToken, String auditorToken) {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, ledgerToken, auditorToken);
+        newOrchestrator(CoordinatorStateAccessor.NAMESPACE, ledgerToken, auditorToken);
 
     // Act & Assert
     assertThatThrownBy(orchestrator::execute)
@@ -333,14 +346,17 @@ class CoordinatorCleanupOrchestratorTest {
     orchestrator.execute();
 
     // Assert
-    verify(scanner).scan(eq(customNamespace), eq(Coordinator.TABLE), any());
+    verify(scanner).scan(eq(customNamespace), eq(CoordinatorStateAccessor.TABLE), any());
   }
 
   @Test
   void close_shouldCloseStorage() {
     // Arrange
     CoordinatorCleanupOrchestrator orchestrator =
-        newOrchestrator(Coordinator.NAMESPACE, createLedgerToken(1000L), createAuditorToken(2000L));
+        newOrchestrator(
+            CoordinatorStateAccessor.NAMESPACE,
+            createLedgerToken(1000L),
+            createAuditorToken(2000L));
 
     // Act
     orchestrator.close();

--- a/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RecordDeleterTest.java
+++ b/coordinator-state-deleter/coordinator-state-cleanup/src/test/java/com/scalar/dl/tools/cleanup/RecordDeleterTest.java
@@ -15,7 +15,7 @@ import com.scalar.db.api.DistributedStorage;
 import com.scalar.db.api.Result;
 import com.scalar.db.exception.storage.ExecutionException;
 import com.scalar.db.io.Key;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ class RecordDeleterTest {
   void execute_shouldDeleteAllSuccessfully() throws Exception {
     // Arrange
     doNothing().when(storage).delete(any(Delete.class));
-    RecordDeleter deleter = new RecordDeleter(storage, Coordinator.NAMESPACE);
+    RecordDeleter deleter = new RecordDeleter(storage, CoordinatorStateAccessor.NAMESPACE);
 
     // Act
     deleter.execute(createScanResult("tx1"));
@@ -56,7 +56,7 @@ class RecordDeleterTest {
   void execute_dbFailureGiven_shouldPropagateException() throws Exception {
     // Arrange
     doThrow(new ExecutionException("DB unavailable")).when(storage).delete(any(Delete.class));
-    RecordDeleter deleter = new RecordDeleter(storage, Coordinator.NAMESPACE);
+    RecordDeleter deleter = new RecordDeleter(storage, CoordinatorStateAccessor.NAMESPACE);
 
     // Act & Assert
     assertThatThrownBy(() -> deleter.execute(createScanResult("tx1")))
@@ -84,7 +84,7 @@ class RecordDeleterTest {
     verify(storage).delete(captor.capture());
     Delete captured = captor.getValue();
     assertThat(captured.forNamespace()).hasValue(namespace);
-    assertThat(captured.forTable()).hasValue(Coordinator.TABLE);
+    assertThat(captured.forTable()).hasValue(CoordinatorStateAccessor.TABLE);
     assertThat((Object) captured.getPartitionKey()).isEqualTo(Key.ofText("tx_id", "tx-abc"));
   }
 }

--- a/coordinator-state-deleter/ledger-finalize-records/src/integration-test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorIntegrationTestBase.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/integration-test/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestratorIntegrationTestBase.java
@@ -22,7 +22,7 @@ import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
 import com.scalar.db.transaction.consensuscommit.Attribute;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import java.nio.file.Path;
@@ -165,8 +165,8 @@ public abstract class LedgerFinalizeOrchestratorIntegrationTestBase {
   private void updateCoordinatorStateToCommitted(String txId) throws Exception {
     Put put =
         Put.newBuilder()
-            .namespace(Coordinator.NAMESPACE)
-            .table(Coordinator.TABLE)
+            .namespace(CoordinatorStateAccessor.NAMESPACE)
+            .table(CoordinatorStateAccessor.TABLE)
             .partitionKey(Key.ofText(Attribute.ID, txId))
             .intValue(Attribute.STATE, TransactionState.COMMITTED.get())
             .bigIntValue(Attribute.CREATED_AT, System.currentTimeMillis())

--- a/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
+++ b/coordinator-state-deleter/ledger-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LedgerFinalizeOrchestrator.java
@@ -6,7 +6,7 @@ import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
 import com.scalar.db.service.TransactionFactory;
-import com.scalar.db.transaction.consensuscommit.Coordinator;
+import com.scalar.db.transaction.consensuscommit.CoordinatorStateAccessor;
 import com.scalar.db.util.ScalarDbUtils;
 import com.scalar.dl.tools.common.CompletionToken;
 import com.scalar.dl.tools.common.CoordinatorStateDeleterException;
@@ -146,7 +146,8 @@ public final class LedgerFinalizeOrchestrator implements AutoCloseable {
 
   private List<String> discoverTables() throws Exception {
     String coordinatorTable =
-        ScalarDbUtils.getFullTableName(Coordinator.NAMESPACE, Coordinator.TABLE);
+        ScalarDbUtils.getFullTableName(
+            CoordinatorStateAccessor.NAMESPACE, CoordinatorStateAccessor.TABLE);
     List<String> tables = new ArrayList<>();
     for (String namespace : admin.getNamespaceNames()) {
       for (String table : admin.getNamespaceTableNames(namespace)) {


### PR DESCRIPTION
## Description

This PR follows an upstream change in ScalarDB that removed `consensuscommit.Coordinator` and moved its constants to `CoordinatorStateAccessor`. It updates all references accordingly so the project compiles against the new snapshot.

## Related issues and/or PRs

- scalar-labs/scalardb#3661

## Changes made

- Rename `Coordinator` -> `CoordinatorStateAccessor`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A