### PR TITLE
Retry auditor lock finalization when not recoverable

### DIFF
--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -16,26 +16,18 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public final class LockFinalizer {
 
-  @VisibleForTesting static final int DEFAULT_MAX_ATTEMPTS = 3;
+  /** The total number of {@code RecoverAssetLock} attempts made for a single lock. */
+  @VisibleForTesting static final int MAX_ATTEMPTS = 3;
 
-  @VisibleForTesting
-  static final long DEFAULT_RETRY_INTERVAL_MS = AuditorInternalValues.LOCK_VALID_PERIOD_MS;
+  /** The wait between attempts; it matches the lock validity period so the lock can expire. */
+  private static final long RETRY_INTERVAL_MS = AuditorInternalValues.LOCK_VALID_PERIOD_MS;
 
   private static final Logger logger = LoggerFactory.getLogger(LockFinalizer.class);
 
   private final AuditorClient auditorClient;
-  private final int maxAttempts;
-  private final long retryIntervalMs;
 
   public LockFinalizer(AuditorClient auditorClient) {
-    this(auditorClient, DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_INTERVAL_MS);
-  }
-
-  @VisibleForTesting
-  LockFinalizer(AuditorClient auditorClient, int maxAttempts, long retryIntervalMs) {
     this.auditorClient = auditorClient;
-    this.maxAttempts = maxAttempts;
-    this.retryIntervalMs = retryIntervalMs;
   }
 
   /**
@@ -45,7 +37,7 @@ public final class LockFinalizer {
    *
    * <p>A {@code NOT_RECOVERABLE} result means the lock is still active (e.g. refreshed by an
    * ongoing reader) and cannot be safely skipped. Rather than abort at once, this method retries up
-   * to {@link #maxAttempts} times, sleeping {@link #retryIntervalMs} between attempts to let the
+   * to {@link #MAX_ATTEMPTS} times, sleeping {@link #RETRY_INTERVAL_MS} between attempts to let the
    * lock expire, and aborts only if every attempt still returns {@code NOT_RECOVERABLE}.
    *
    * @throws InterruptedException if the thread is interrupted while sleeping between retries, so
@@ -65,7 +57,7 @@ public final class LockFinalizer {
     AssetLockRecoveryRequest rpcRequest =
         AssetLockRecoveryRequest.newBuilder().setNamespace(namespace).setAssetId(assetId).build();
 
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+    for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
 
       if (rpcResult == LockRecoveryResult.SUCCEEDED || rpcResult == LockRecoveryResult.NOT_NEEDED) {
@@ -82,18 +74,18 @@ public final class LockFinalizer {
       }
 
       // NOT_RECOVERABLE: the lock is not yet expired. Retry unless this was the last attempt.
-      if (attempt < maxAttempts) {
+      if (attempt < MAX_ATTEMPTS) {
         logger.info(
             "Asset {} in namespace {} is still in use. Retrying finalization (attempt {}/{})",
             assetId,
             namespace,
             attempt,
-            maxAttempts);
-        Thread.sleep(retryIntervalMs);
+            MAX_ATTEMPTS);
+        Thread.sleep(RETRY_INTERVAL_MS);
       }
     }
 
     throw new ScalarDlCleanupException(
-        ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE, assetId, namespace, maxAttempts);
+        ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE, assetId, namespace, MAX_ATTEMPTS);
   }
 }

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -1,5 +1,6 @@
 package com.scalar.dl.tools.cleanup;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.db.api.Result;
 import com.scalar.dl.auditor.ordering.LockRecoveryResult;
 import com.scalar.dl.client.service.AuditorClient;
@@ -8,23 +9,49 @@ import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.ScalarDlCleanupError;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
 import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Finalizes unreleased asset locks by issuing {@code RecoverAssetLock} RPCs to the Auditor. */
 @ThreadSafe
 public final class LockFinalizer {
 
+  @VisibleForTesting static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+  @VisibleForTesting
+  static final long DEFAULT_RETRY_INTERVAL_MS = AuditorInternalValues.LOCK_VALID_PERIOD_MS;
+
+  private static final Logger logger = LoggerFactory.getLogger(LockFinalizer.class);
+
   private final AuditorClient auditorClient;
+  private final int maxAttempts;
+  private final long retryIntervalMs;
 
   public LockFinalizer(AuditorClient auditorClient) {
+    this(auditorClient, DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_INTERVAL_MS);
+  }
+
+  @VisibleForTesting
+  LockFinalizer(AuditorClient auditorClient, int maxAttempts, long retryIntervalMs) {
     this.auditorClient = auditorClient;
+    this.maxAttempts = maxAttempts;
+    this.retryIntervalMs = retryIntervalMs;
   }
 
   /**
    * Finalizes a lock record by issuing the synchronous {@code RecoverAssetLock} RPC. The RPC
    * completes recovery before returning, so a {@code SUCCEEDED} or {@code NOT_NEEDED} result
    * confirms the lock is released; no re-read is required.
+   *
+   * <p>A {@code NOT_RECOVERABLE} result means the lock is still active (e.g. refreshed by an
+   * ongoing reader) and cannot be safely skipped. Rather than abort at once, this method retries up
+   * to {@link #maxAttempts} times, sleeping {@link #retryIntervalMs} between attempts to let the
+   * lock expire, and aborts only if every attempt still returns {@code NOT_RECOVERABLE}.
+   *
+   * @throws InterruptedException if the thread is interrupted while sleeping between retries, so
+   *     the scan can be canceled promptly.
    */
-  public void execute(String namespace, Result result) {
+  public void execute(String namespace, Result result) throws InterruptedException {
     String assetId = result.getText(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     if (assetId == null) {
       // The id column is the partition key of the asset_lock table, so it should never be null for
@@ -38,21 +65,35 @@ public final class LockFinalizer {
     AssetLockRecoveryRequest rpcRequest =
         AssetLockRecoveryRequest.newBuilder().setNamespace(namespace).setAssetId(assetId).build();
 
-    LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
-    if (rpcResult == LockRecoveryResult.FAILED) {
-      throw new ScalarDlCleanupException(
-          ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_FAILED, assetId, namespace);
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
+
+      if (rpcResult == LockRecoveryResult.SUCCEEDED || rpcResult == LockRecoveryResult.NOT_NEEDED) {
+        return;
+      }
+
+      if (rpcResult == LockRecoveryResult.FAILED) {
+        throw new ScalarDlCleanupException(
+            ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_FAILED, assetId, namespace);
+      }
+
+      if (rpcResult != LockRecoveryResult.NOT_RECOVERABLE) {
+        throw new IllegalStateException("Unexpected lock recovery result: " + rpcResult);
+      }
+
+      // NOT_RECOVERABLE: the lock is not yet expired. Retry unless this was the last attempt.
+      if (attempt < maxAttempts) {
+        logger.info(
+            "Asset {} in namespace {} is still in use. Retrying finalization (attempt {}/{})",
+            assetId,
+            namespace,
+            attempt,
+            maxAttempts);
+        Thread.sleep(retryIntervalMs);
+      }
     }
 
-    // TODO: NOT_RECOVERABLE means the lock is still active and currently aborts the whole run. A
-    //  follow-up will instead defer such locks and retry them after the scan, so a single active
-    //  lock no longer blocks finalization.
-    if (rpcResult == LockRecoveryResult.NOT_RECOVERABLE) {
-      throw new RuntimeException(
-          String.format(
-              "RecoverAssetLock RPC returned NOT_RECOVERABLE for asset %s in namespace %s",
-              assetId, namespace));
-    }
-    // SUCCEEDED or NOT_NEEDED: the lock has been released.
+    throw new ScalarDlCleanupException(
+        ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE, assetId, namespace, maxAttempts);
   }
 }

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -19,15 +19,20 @@ public final class LockFinalizer {
   /** The total number of {@code RecoverAssetLock} attempts made for a single lock. */
   @VisibleForTesting static final int MAX_ATTEMPTS = 3;
 
-  /** The wait between attempts; it matches the lock validity period so the lock can expire. */
-  private static final long RETRY_INTERVAL_MS = AuditorInternalValues.LOCK_VALID_PERIOD_MS;
-
   private static final Logger logger = LoggerFactory.getLogger(LockFinalizer.class);
 
   private final AuditorClient auditorClient;
 
+  private final long retryIntervalMs;
+
   public LockFinalizer(AuditorClient auditorClient) {
+    this(auditorClient, AuditorInternalValues.LOCK_VALID_PERIOD_MS);
+  }
+
+  @VisibleForTesting
+  LockFinalizer(AuditorClient auditorClient, long retryIntervalMs) {
     this.auditorClient = auditorClient;
+    this.retryIntervalMs = retryIntervalMs;
   }
 
   /**
@@ -37,8 +42,8 @@ public final class LockFinalizer {
    *
    * <p>A {@code NOT_RECOVERABLE} result means the lock is still active (e.g. refreshed by an
    * ongoing reader) and cannot be safely skipped. Rather than abort at once, this method retries up
-   * to {@link #MAX_ATTEMPTS} times, sleeping {@link #RETRY_INTERVAL_MS} between attempts to let the
-   * lock expire, and aborts only if every attempt still returns {@code NOT_RECOVERABLE}.
+   * to {@link #MAX_ATTEMPTS} times, sleeping between attempts to let the lock expire, and aborts
+   * only if every attempt still returns {@code NOT_RECOVERABLE}.
    *
    * @throws InterruptedException if the thread is interrupted while sleeping between retries, so
    *     the scan can be canceled promptly.
@@ -81,7 +86,7 @@ public final class LockFinalizer {
             namespace,
             attempt,
             MAX_ATTEMPTS);
-        Thread.sleep(RETRY_INTERVAL_MS);
+        Thread.sleep(retryIntervalMs);
       }
     }
 

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/FinalizeAssetLockHandlerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/FinalizeAssetLockHandlerTest.java
@@ -81,7 +81,7 @@ class FinalizeAssetLockHandlerTest {
   }
 
   @Test
-  void handle_finalizeFailureGiven_shouldPropagateExceptionAndNotCount() {
+  void handle_finalizeFailureGiven_shouldPropagateExceptionAndNotCount() throws Exception {
     // Arrange
     Result record = mock(Result.class);
     when(stateChecker.needsFinalization(record)).thenReturn(true);

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,13 +22,17 @@ import org.mockito.ArgumentCaptor;
 
 class LockFinalizerTest {
 
+  // A short retry interval keeps the retry tests fast; the number of attempts still matters.
+  private static final int MAX_ATTEMPTS = 3;
+  private static final long RETRY_INTERVAL_MS = 0L;
+
   private AuditorClient auditorClient;
   private LockFinalizer finalizer;
 
   @BeforeEach
   void setUp() {
     auditorClient = mock(AuditorClient.class);
-    finalizer = new LockFinalizer(auditorClient);
+    finalizer = new LockFinalizer(auditorClient, MAX_ATTEMPTS, RETRY_INTERVAL_MS);
   }
 
   private Result createScanResult() {
@@ -38,7 +43,7 @@ class LockFinalizerTest {
   }
 
   @Test
-  void execute_shouldSendRpcWithNamespaceAndAssetId() {
+  void execute_shouldSendRpcWithNamespaceAndAssetId() throws InterruptedException {
     // Arrange
     when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
         .thenReturn(LockRecoveryResult.SUCCEEDED);
@@ -55,7 +60,7 @@ class LockFinalizerTest {
   }
 
   @Test
-  void execute_notNeededGiven_shouldNotThrow() {
+  void execute_notNeededGiven_shouldNotThrow() throws InterruptedException {
     // Arrange — NOT_NEEDED means the lock is already released.
     when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
         .thenReturn(LockRecoveryResult.NOT_NEEDED);
@@ -103,14 +108,69 @@ class LockFinalizerTest {
   }
 
   @Test
-  void execute_rpcNotRecoverableGiven_shouldThrowException() {
+  void execute_rpcNotRecoverableForEveryAttemptGiven_shouldRetryUpToMaxAttemptsThenThrow() {
     // Arrange
     when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
         .thenReturn(LockRecoveryResult.NOT_RECOVERABLE);
 
     // Act & Assert
     assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("NOT_RECOVERABLE");
+        .isInstanceOf(ScalarDlCleanupException.class)
+        .hasMessageContaining(ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE.buildCode());
+    verify(auditorClient, times(MAX_ATTEMPTS)).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_notRecoverableThenReleasedGiven_shouldRetryAndSucceed() throws InterruptedException {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenReturn(LockRecoveryResult.NOT_RECOVERABLE)
+        .thenReturn(LockRecoveryResult.SUCCEEDED);
+
+    // Act
+    finalizer.execute("default", createScanResult());
+
+    // Assert
+    verify(auditorClient, times(2)).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_interruptedBeforeRetrySleepGiven_shouldThrowInterruptedExceptionPromptly() {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenReturn(LockRecoveryResult.NOT_RECOVERABLE);
+    LockFinalizer interruptibleFinalizer = new LockFinalizer(auditorClient, MAX_ATTEMPTS, 60_000L);
+    Thread.currentThread().interrupt();
+
+    // Act & Assert
+    // The interrupted sleep aborts finalization after the first attempt.
+    assertThatThrownBy(() -> interruptibleFinalizer.execute("default", createScanResult()))
+        .isInstanceOf(InterruptedException.class);
+    verify(auditorClient, times(1)).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_unexpectedResultGiven_shouldThrowWithoutRetrying() {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class))).thenReturn(null);
+
+    // Act & Assert
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(IllegalStateException.class);
+    verify(auditorClient, times(1)).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_failedAfterNotRecoverableGiven_shouldThrowWithoutFurtherRetries() {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenReturn(LockRecoveryResult.NOT_RECOVERABLE)
+        .thenReturn(LockRecoveryResult.FAILED);
+
+    // Act & Assert
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(ScalarDlCleanupException.class)
+        .hasMessageContaining(ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_FAILED.buildCode());
+    verify(auditorClient, times(2)).recover(any(AssetLockRecoveryRequest.class));
   }
 }

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -22,17 +22,13 @@ import org.mockito.ArgumentCaptor;
 
 class LockFinalizerTest {
 
-  // A short retry interval keeps the retry tests fast; the number of attempts still matters.
-  private static final int MAX_ATTEMPTS = 3;
-  private static final long RETRY_INTERVAL_MS = 0L;
-
   private AuditorClient auditorClient;
   private LockFinalizer finalizer;
 
   @BeforeEach
   void setUp() {
     auditorClient = mock(AuditorClient.class);
-    finalizer = new LockFinalizer(auditorClient, MAX_ATTEMPTS, RETRY_INTERVAL_MS);
+    finalizer = new LockFinalizer(auditorClient);
   }
 
   private Result createScanResult() {
@@ -117,7 +113,8 @@ class LockFinalizerTest {
     assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
         .isInstanceOf(ScalarDlCleanupException.class)
         .hasMessageContaining(ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE.buildCode());
-    verify(auditorClient, times(MAX_ATTEMPTS)).recover(any(AssetLockRecoveryRequest.class));
+    verify(auditorClient, times(LockFinalizer.MAX_ATTEMPTS))
+        .recover(any(AssetLockRecoveryRequest.class));
   }
 
   @Test
@@ -139,12 +136,11 @@ class LockFinalizerTest {
     // Arrange
     when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
         .thenReturn(LockRecoveryResult.NOT_RECOVERABLE);
-    LockFinalizer interruptibleFinalizer = new LockFinalizer(auditorClient, MAX_ATTEMPTS, 60_000L);
     Thread.currentThread().interrupt();
 
     // Act & Assert
     // The interrupted sleep aborts finalization after the first attempt.
-    assertThatThrownBy(() -> interruptibleFinalizer.execute("default", createScanResult()))
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
         .isInstanceOf(InterruptedException.class);
     verify(auditorClient, times(1)).recover(any(AssetLockRecoveryRequest.class));
   }

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -132,6 +132,7 @@ class LockFinalizerTest {
   }
 
   @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   void execute_interruptedBeforeRetrySleepGiven_shouldThrowInterruptedExceptionPromptly() {
     // Arrange
     when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
@@ -140,8 +141,12 @@ class LockFinalizerTest {
 
     // Act & Assert
     // The interrupted sleep aborts finalization after the first attempt.
-    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
-        .isInstanceOf(InterruptedException.class);
+    try {
+      assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+          .isInstanceOf(InterruptedException.class);
+    } finally {
+      Thread.interrupted();
+    }
     verify(auditorClient, times(1)).recover(any(AssetLockRecoveryRequest.class));
   }
 

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -22,13 +22,16 @@ import org.mockito.ArgumentCaptor;
 
 class LockFinalizerTest {
 
+  // Retry interval used in tests so the retry path does not sleep for the real (15s) interval.
+  private static final long NO_RETRY_INTERVAL_MS = 0L;
+
   private AuditorClient auditorClient;
   private LockFinalizer finalizer;
 
   @BeforeEach
   void setUp() {
     auditorClient = mock(AuditorClient.class);
-    finalizer = new LockFinalizer(auditorClient);
+    finalizer = new LockFinalizer(auditorClient, NO_RETRY_INTERVAL_MS);
   }
 
   private Result createScanResult() {

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
@@ -104,7 +104,14 @@ public enum ScalarDlCleanupError implements ScalarDlToolsError {
       "003",
       "The asset lock recovery failed for asset %s in namespace %s.",
       "",
-      "Verify that the Auditor is healthy and reachable.");
+      "Verify that the Auditor is healthy and reachable."),
+  RECOVER_ASSET_LOCK_NOT_RECOVERABLE(
+      Category.INTERNAL_ERROR,
+      "004",
+      "The asset lock for asset %s in namespace %s is still not recoverable after %d attempts; "
+          + "the lock is being kept active.",
+      "",
+      "Re-run the command after the affected asset becomes quiescent.");
 
   private static final String COMPONENT_NAME = "DL-TOOLS";
 


### PR DESCRIPTION
## Description

This PR makes `auditor-finalize-records` retry lock finalization instead of aborting immediately when the Auditor returns `NOT_RECOVERABLE`. Previously, a single lock held by an active reader aborted the whole run, so finalization could never progress in environments with ongoing read activity. The tool now sleeps and retries, giving such locks a chance to expire before giving up.

## Related issues and/or PRs

N/A

## Changes made

- Retry `RecoverAssetLock` on `NOT_RECOVERABLE` up to 3 times, sleeping 15s (the lock validity period) between attempts.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A