### PR TITLE
Upgrade the build from Java 8 to a Java 21 toolchain

### DIFF
--- a/scalardl-cleanup/build.gradle
+++ b/scalardl-cleanup/build.gradle
@@ -82,12 +82,9 @@ subprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    tasks.withType(JavaCompile).configureEach {
-        options.release = 8
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
     }
 
     tasks.withType(Javadoc).configureEach {

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommandTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommandTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InOrder;
 import picocli.CommandLine;
 
-// The Charset overloads errorprone's JdkObsolete recommends are Java 10+ and do not compile under
-// this module's --release 8 target, so the tests use the "UTF-8" String overloads deliberately.
-@SuppressWarnings("JdkObsolete")
 public class AuditorFinalizeRecordsCommandTest {
 
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -39,7 +36,7 @@ public class AuditorFinalizeRecordsCommandTest {
   @BeforeEach
   void setUp() throws Exception {
     out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out, true, "UTF-8"));
+    System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
   }
 
   @AfterEach
@@ -54,7 +51,7 @@ public class AuditorFinalizeRecordsCommandTest {
   }
 
   private JsonNode captured() throws Exception {
-    return mapper.readTree(out.toString("UTF-8"));
+    return mapper.readTree(out.toString(StandardCharsets.UTF_8));
   }
 
   @Test
@@ -131,7 +128,7 @@ public class AuditorFinalizeRecordsCommandTest {
     JsonNode json = captured();
     assertThat(json.get("status_code").asText()).isEqualTo("INTERNAL_ERROR");
     assertThat(json.get("error_message").asText()).isEqualTo("finalize failed");
-    assertThat(out.toString("UTF-8")).doesNotContain("completion_token");
+    assertThat(out.toString(StandardCharsets.UTF_8)).doesNotContain("completion_token");
   }
 
   @Test
@@ -170,6 +167,6 @@ public class AuditorFinalizeRecordsCommandTest {
     JsonNode json = captured();
     assertThat(json.get("status_code").asText()).isEqualTo("INTERNAL_ERROR");
     assertThat(json.get("error_message").asText()).isEqualTo("cleanup failed");
-    assertThat(out.toString("UTF-8")).doesNotContain("completion_token");
+    assertThat(out.toString(StandardCharsets.UTF_8)).doesNotContain("completion_token");
   }
 }

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/CommonTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/CommonTest.java
@@ -8,13 +8,11 @@ import com.scalar.dl.tools.common.Category;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-// The Charset overloads errorprone's JdkObsolete recommends are Java 10+ and do not compile under
-// this module's --release 8 target, so the tests use the "UTF-8" String overloads deliberately.
-@SuppressWarnings("JdkObsolete")
 public class CommonTest {
 
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -25,7 +23,7 @@ public class CommonTest {
   @BeforeEach
   void setUp() throws Exception {
     out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out, true, "UTF-8"));
+    System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
   }
 
   @AfterEach
@@ -34,7 +32,7 @@ public class CommonTest {
   }
 
   private JsonNode captured() throws Exception {
-    return mapper.readTree(out.toString("UTF-8"));
+    return mapper.readTree(out.toString(StandardCharsets.UTF_8));
   }
 
   @Test

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/CoordinatorStateCleanupCommandTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/CoordinatorStateCleanupCommandTest.java
@@ -30,9 +30,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import picocli.CommandLine;
 
-// The Charset overloads errorprone's JdkObsolete recommends are Java 10+ and do not compile under
-// this module's --release 8 target, so the tests use the "UTF-8" String overloads deliberately.
-@SuppressWarnings("JdkObsolete")
 public class CoordinatorStateCleanupCommandTest {
 
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -50,7 +47,7 @@ public class CoordinatorStateCleanupCommandTest {
   @BeforeEach
   void setUp() throws Exception {
     out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out, true, "UTF-8"));
+    System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
   }
 
   @AfterEach
@@ -65,7 +62,7 @@ public class CoordinatorStateCleanupCommandTest {
   }
 
   private JsonNode captured() throws Exception {
-    return mapper.readTree(out.toString("UTF-8"));
+    return mapper.readTree(out.toString(StandardCharsets.UTF_8));
   }
 
   @Test

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/LedgerFinalizeRecordsCommandTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/LedgerFinalizeRecordsCommandTest.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
-// The Charset overloads errorprone's JdkObsolete recommends are Java 10+ and do not compile under
-// this module's --release 8 target, so the tests use the "UTF-8" String overloads deliberately.
-@SuppressWarnings("JdkObsolete")
 public class LedgerFinalizeRecordsCommandTest {
 
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -33,7 +30,7 @@ public class LedgerFinalizeRecordsCommandTest {
   @BeforeEach
   void setUp() throws Exception {
     out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out, true, "UTF-8"));
+    System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
   }
 
   @AfterEach
@@ -48,7 +45,7 @@ public class LedgerFinalizeRecordsCommandTest {
   }
 
   private JsonNode captured() throws Exception {
-    return mapper.readTree(out.toString("UTF-8"));
+    return mapper.readTree(out.toString(StandardCharsets.UTF_8));
   }
 
   @Test

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/ScalarDlCleanupTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/ScalarDlCleanupTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scalar.dl.tools.common.Category;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,9 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-// The Charset overloads errorprone's JdkObsolete recommends are Java 10+ and do not compile under
-// this module's --release 8 target, so the tests use the "UTF-8" String overloads deliberately.
-@SuppressWarnings("JdkObsolete")
 public class ScalarDlCleanupTest {
 
   private static final ObjectMapper mapper = new ObjectMapper();
@@ -39,7 +37,7 @@ public class ScalarDlCleanupTest {
   @BeforeEach
   void setUp() throws Exception {
     out = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(out, true, "UTF-8"));
+    System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
 
     // Capture what CommonOptions logs so the --stacktrace behavior can be asserted. slf4j delegates
     // to the same underlying log4j2 logger, so an appender attached here sees CommonOptions'
@@ -58,7 +56,7 @@ public class ScalarDlCleanupTest {
   }
 
   private JsonNode captured() throws Exception {
-    return mapper.readTree(out.toString("UTF-8"));
+    return mapper.readTree(out.toString(StandardCharsets.UTF_8));
   }
 
   private void assertUserErrorJson() throws Exception {
@@ -169,7 +167,7 @@ public class ScalarDlCleanupTest {
     // Assert
     String expectedVersion = String.join(" ", new VersionProvider().getVersion());
     assertThat(exitCode).isZero();
-    assertThat(out.toString("UTF-8")).contains(expectedVersion);
+    assertThat(out.toString(StandardCharsets.UTF_8)).contains(expectedVersion);
   }
 
   /** A log4j2 appender that records the formatted message of every {@code ERROR} event. */


### PR DESCRIPTION
## Description

This PR upgrades the scalardl-cleanup build from a Java 8 target to a Java 21 toolchain. The tool was originally intended to be shipped as a jar and run directly from an administrator's machine, which required Java 8 compatibility as well as ScalarDL Client. Since we have decided to distribute the tool as a container image instead, that constraint no longer applies, so we can move to a modern JDK and simplify the build accordingly.


## Related issues and/or PRs

N/A

## Changes made

- Replace the sourceCompatibility/targetCompatibility and options.release = 8 settings with a Java 21 toolchain in build.gradle.
- Switch the deprecated "UTF-8" string overloads to the StandardCharsets.UTF_8 Charset overloads in the CLI tests.
- Remove the now-unneeded @SuppressWarnings("JdkObsolete") annotations.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A