### PR TITLE
Suppress verbose Azure Cosmos SDK log

### DIFF
--- a/scalardl-cleanup/cli/src/main/resources/log4j2.properties
+++ b/scalardl-cleanup/cli/src/main/resources/log4j2.properties
@@ -8,3 +8,7 @@ appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
 rootLogger.level=info
 rootLogger.appenderRef.stderr.ref=stderr
+
+# Silence the Azure Cosmos SDK's verbose startup/connection chatter.
+logger.cosmos.name=com.azure.cosmos
+logger.cosmos.level=error


### PR DESCRIPTION
## Description

This PR suppresses the verbose Azure Cosmos SDK logs that flood the console when running the cleanup CLI commands. 

The SDK's startup and connection chatter (e.g., Initializing DocumentClient, db account retrieved, Cosmos Client ... started up) is logged at INFO/WARN and makes the tool's own output hard to read. Raising the `com.azure.cosmos` logger to error keeps genuine Cosmos failures visible while hiding the noise.

## Related issues and/or PRs

N/A

## Changes made

- Add a `com.azure.cosmos` logger set to error level in the CLI log4j2.properties to silence the SDK's startup/connection chatter.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A