### PR TITLE
Add Docker build configuration for ScalarDL Cleanup CLI

### DIFF
--- a/scalardl-cleanup/cli/Dockerfile
+++ b/scalardl-cleanup/cli/Dockerfile
@@ -1,0 +1,39 @@
+FROM eclipse-temurin:21-jre-jammy
+
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -r --gid 201 scalar \
+ && useradd -r --uid 201 -g scalar scalar
+
+WORKDIR /scalar
+
+COPY scalardl-cleanup.tar docker-entrypoint.sh /tmp/build/
+RUN mkdir -p /scalar/scalardl-cleanup \
+ && tar -xf /tmp/build/scalardl-cleanup.tar -C /scalar/scalardl-cleanup --strip-components=1 \
+ && cp /tmp/build/docker-entrypoint.sh /scalar/scalardl-cleanup/ \
+ && chmod +x /scalar/scalardl-cleanup/docker-entrypoint.sh \
+ && rm -rf /tmp/build \
+ && chown -R 201:201 /scalar
+
+USER 201
+
+ENV JAVA_OPT_MAX_RAM_PERCENTAGE='60.0'
+
+ARG IMAGE_NAME
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+
+LABEL name="${IMAGE_NAME}" \
+      maintainer="Scalar, Inc." \
+      vendor="Scalar, Inc." \
+      version="${IMAGE_VERSION}" \
+      release="${IMAGE_RELEASE}" \
+      summary="ScalarDL Cleanup Tools Container Image" \
+      description="Command-line tools that let ScalarDL operators safely reclaim space by removing stale records left behind by completed transactions from ScalarDB's coordinator.state table (Ledger) and the Auditor's asset_lock/request_proof tables."
+
+WORKDIR /scalar/scalardl-cleanup
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+CMD ["--help"]

--- a/scalardl-cleanup/cli/Dockerfile
+++ b/scalardl-cleanup/cli/Dockerfile
@@ -30,7 +30,7 @@ LABEL name="${IMAGE_NAME}" \
       version="${IMAGE_VERSION}" \
       release="${IMAGE_RELEASE}" \
       summary="ScalarDL Cleanup Tools Container Image" \
-      description="Command-line tools that let ScalarDL operators safely reclaim space by removing stale records left behind by completed transactions from ScalarDB's coordinator.state table (Ledger) and the Auditor's asset_lock/request_proof tables."
+      description="Command-line tools that let ScalarDL operators safely reclaim space by removing stale records left behind by completed transactions from Ledger's coordinator table and the Auditor's request proof table."
 
 WORKDIR /scalar/scalardl-cleanup
 

--- a/scalardl-cleanup/cli/Dockerfile
+++ b/scalardl-cleanup/cli/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 WORKDIR /scalar
 
+# Deliberately left owned by root:root (COPY's default — no --chown): uid 201 gets
+# read/execute but cannot write, so a compromised JVM process cannot rewrite the
+# entrypoint or the jars it is about to load.
 COPY --from=builder /out /scalar/scalardl-cleanup
 
 USER 201

--- a/scalardl-cleanup/cli/Dockerfile
+++ b/scalardl-cleanup/cli/Dockerfile
@@ -1,3 +1,11 @@
+FROM eclipse-temurin:21-jre-jammy AS builder
+
+COPY scalardl-cleanup.tar docker-entrypoint.sh /tmp/build/
+RUN mkdir -p /out \
+ && tar -xf /tmp/build/scalardl-cleanup.tar -C /out --strip-components=1 \
+ && cp /tmp/build/docker-entrypoint.sh /out/ \
+ && chmod +x /out/docker-entrypoint.sh
+
 FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
@@ -8,13 +16,7 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 WORKDIR /scalar
 
-COPY scalardl-cleanup.tar docker-entrypoint.sh /tmp/build/
-RUN mkdir -p /scalar/scalardl-cleanup \
- && tar -xf /tmp/build/scalardl-cleanup.tar -C /scalar/scalardl-cleanup --strip-components=1 \
- && cp /tmp/build/docker-entrypoint.sh /scalar/scalardl-cleanup/ \
- && chmod +x /scalar/scalardl-cleanup/docker-entrypoint.sh \
- && rm -rf /tmp/build \
- && chown -R 201:201 /scalar
+COPY --from=builder /out /scalar/scalardl-cleanup
 
 USER 201
 

--- a/scalardl-cleanup/cli/build.gradle
+++ b/scalardl-cleanup/cli/build.gradle
@@ -57,3 +57,38 @@ spotbugs {
 
 spotbugsMain { reports.create('html') { required = true } }
 spotbugsTest { reports.create('html') { required = true } }
+
+// Name the distribution archive predictably so the Dockerfile can reference it
+// without embedding the version.
+distTar {
+    archiveFileName = 'scalardl-cleanup.tar'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// Docker image build. The version can be overridden with -PdockerVersion=<v>.
+def dockerVersion = project.properties['dockerVersion'] ?: project.version
+def imageName = 'scalardl-cleanup'
+def imageVersion = dockerVersion
+def imageRelease = System.currentTimeMillis().toString()
+
+tasks.register('copyFilesToDockerBuildContextDir', Copy) {
+    description = 'Copy files to a temporary folder to build the Docker image'
+    dependsOn distTar
+    from('Dockerfile')
+    from('docker-entrypoint.sh')
+    from(tasks.distTar.archiveFile)
+    into('build/docker')
+}
+
+tasks.register('docker', Exec) {
+    description = 'Build the ScalarDL Cleanup tools Docker image'
+    group = 'docker'
+    dependsOn copyFilesToDockerBuildContextDir
+    workingDir 'build/docker'
+    commandLine 'docker', 'build',
+            '--build-arg', "IMAGE_NAME=${imageName}",
+            '--build-arg', "IMAGE_VERSION=${imageVersion}",
+            '--build-arg', "IMAGE_RELEASE=${imageRelease}",
+            '--tag', "ghcr.io/scalar-labs/${imageName}:${imageVersion}",
+            '.'
+}

--- a/scalardl-cleanup/cli/build.gradle
+++ b/scalardl-cleanup/cli/build.gradle
@@ -62,7 +62,6 @@ spotbugsTest { reports.create('html') { required = true } }
 // without embedding the version.
 distTar {
     archiveFileName = 'scalardl-cleanup.tar'
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 // Docker image build. The version can be overridden with -PdockerVersion=<v>.

--- a/scalardl-cleanup/cli/docker-entrypoint.sh
+++ b/scalardl-cleanup/cli/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Let the JVM size its heap relative to the container's memory limit. This is
+# the same mechanism the ScalarDL Ledger/Auditor images use.
+export JAVA_OPTS="${JAVA_OPTS:-} -XX:MaxRAMPercentage=${JAVA_OPT_MAX_RAM_PERCENTAGE}"
+
+exec ./bin/scalardl-cleanup "$@"


### PR DESCRIPTION
## Description

This PR adds a Docker build configuration so the `scalardl-cleanup` CLI tools can be distributed and run as a container image on `ghcr.io/scalar-labs/scalardl-cleanup`.

## Related issues and/or PRs

N/A

## Changes made

- Add a `Dockerfile` that runs as a non-root `scalar` user (uid/gid 201) and unpacks the distribution tarball into `/scalar/scalardl-cleanup`.
- Add `docker-entrypoint.sh` that sizes the JVM heap from the container memory limit and execs the CLI launcher.
- Add Gradle `docker` and `copyFilesToDockerBuildContextDir` tasks, with a predictable `distTar` archive name and a `-PdockerVersion` override.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

A release setting will be added in a separate PR.

## Release notes

N/A