### PR TITLE
Simplify finalize-auditor configuration to a single properties file

### DIFF
--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
@@ -1,0 +1,69 @@
+package com.scalar.dl.tools.cleanup;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.dl.client.config.ClientConfig;
+import com.scalar.dl.ledger.config.ConfigUtils;
+import com.scalar.dl.ledger.config.GrpcClientConfig;
+import com.scalar.dl.ledger.config.TargetConfig;
+import com.scalar.dl.tools.common.AuditorInternalValues;
+import java.util.Properties;
+
+/** Auditor-tool-specific settings for {@code auditor-finalize-records}. */
+public final class AuditorFinalizeConfig {
+
+  // Mirror ClientConfig.DEFAULT_* since they are private.
+  @VisibleForTesting static final long DEFAULT_GRPC_DEADLINE_MS = 60000;
+  @VisibleForTesting static final String DEFAULT_AUDITOR_HOST = "localhost";
+  @VisibleForTesting static final int DEFAULT_AUDITOR_PORT = 40051;
+  @VisibleForTesting static final int DEFAULT_AUDITOR_PRIVILEGED_PORT = 40052;
+  @VisibleForTesting static final boolean DEFAULT_AUDITOR_TLS_ENABLED = false;
+
+  private final String baseNamespace;
+  private final TargetConfig auditorTargetConfig;
+
+  public AuditorFinalizeConfig(Properties props) {
+    this.baseNamespace =
+        props.getProperty(
+            AuditorInternalValues.AUDITOR_NAMESPACE_PROPERTY,
+            AuditorInternalValues.DEFAULT_BASE_NAMESPACE);
+    this.auditorTargetConfig = buildAuditorTargetConfig(props);
+  }
+
+  @VisibleForTesting
+  static TargetConfig buildAuditorTargetConfig(Properties props) {
+    // The CA root cert is taken from the inline PEM if set, otherwise read from the cert file path.
+    String caRootCertPem =
+        ConfigUtils.getString(props, ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PEM, null);
+    String caRootCert =
+        caRootCertPem != null
+            ? caRootCertPem
+            : ConfigUtils.getStringFromFilePath(
+                props, ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PATH, null);
+
+    return TargetConfig.newBuilder()
+        .host(ConfigUtils.getString(props, ClientConfig.AUDITOR_HOST, DEFAULT_AUDITOR_HOST))
+        .port(ConfigUtils.getInt(props, ClientConfig.AUDITOR_PORT, DEFAULT_AUDITOR_PORT))
+        .privilegedPort(
+            ConfigUtils.getInt(
+                props, ClientConfig.AUDITOR_PRIVILEGED_PORT, DEFAULT_AUDITOR_PRIVILEGED_PORT))
+        .tlsEnabled(
+            ConfigUtils.getBoolean(
+                props, ClientConfig.AUDITOR_TLS_ENABLED, DEFAULT_AUDITOR_TLS_ENABLED))
+        .tlsCaRootCert(caRootCert)
+        .tlsOverrideAuthority(
+            ConfigUtils.getString(props, ClientConfig.AUDITOR_TLS_OVERRIDE_AUTHORITY, null))
+        .grpcClientConfig(
+            GrpcClientConfig.newBuilder().deadlineDurationMillis(DEFAULT_GRPC_DEADLINE_MS).build())
+        .build();
+  }
+
+  /** Get the Auditor base namespace, default {@code auditor}. */
+  public String getBaseNamespace() {
+    return baseNamespace;
+  }
+
+  /** Get the config used to reach the Auditor server. */
+  public TargetConfig getAuditorTargetConfig() {
+    return auditorTargetConfig;
+  }
+}

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
@@ -52,6 +52,8 @@ public final class AuditorFinalizeConfig {
         .tlsCaRootCert(caRootCert)
         .tlsOverrideAuthority(
             ConfigUtils.getString(props, ClientConfig.AUDITOR_TLS_OVERRIDE_AUTHORITY, null))
+        .authorizationCredential(
+            ConfigUtils.getString(props, ClientConfig.AUDITOR_AUTHORIZATION_CREDENTIAL, null))
         .grpcClientConfig(
             GrpcClientConfig.newBuilder().deadlineDurationMillis(DEFAULT_GRPC_DEADLINE_MS).build())
         .build();

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
@@ -54,8 +54,12 @@ public final class AuditorFinalizeConfig {
             ConfigUtils.getString(props, ClientConfig.AUDITOR_TLS_OVERRIDE_AUTHORITY, null))
         .authorizationCredential(
             ConfigUtils.getString(props, ClientConfig.AUDITOR_AUTHORIZATION_CREDENTIAL, null))
-        // Fixed deadline, not configurable: this tool runs in the same cluster as the Auditor, so
-        // 60s is always ample for the synchronous RecoverAssetLock RPC.
+        // The gRPC client settings are fixed, not configurable. The deadline is 60s, which is
+        // always ample for the synchronous RecoverAssetLock RPC since this tool runs in the same
+        // cluster as the Auditor. The max sizes of the inbound message and metadata (i.e., the
+        // response and its headers/trailers from the Auditor) are left at the gRPC defaults (4 MiB
+        // and 8 KiB), which are more than enough since the response carries only a single result
+        // code.
         .grpcClientConfig(
             GrpcClientConfig.newBuilder().deadlineDurationMillis(DEFAULT_GRPC_DEADLINE_MS).build())
         .build();

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfig.java
@@ -54,6 +54,8 @@ public final class AuditorFinalizeConfig {
             ConfigUtils.getString(props, ClientConfig.AUDITOR_TLS_OVERRIDE_AUTHORITY, null))
         .authorizationCredential(
             ConfigUtils.getString(props, ClientConfig.AUDITOR_AUTHORIZATION_CREDENTIAL, null))
+        // Fixed deadline, not configurable: this tool runs in the same cluster as the Auditor, so
+        // 60s is always ample for the synchronous RecoverAssetLock RPC.
         .grpcClientConfig(
             GrpcClientConfig.newBuilder().deadlineDurationMillis(DEFAULT_GRPC_DEADLINE_MS).build())
         .build();

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestrator.java
@@ -9,7 +9,6 @@ import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.StorageFactory;
-import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
@@ -18,7 +17,6 @@ import com.scalar.dl.tools.common.StorageValidator;
 import com.scalar.dl.tools.scan.ResumableScanner;
 import com.scalar.dl.tools.scan.ResumableScannerFactory;
 import com.scalar.dl.tools.scan.ScanResult;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -70,42 +68,29 @@ public final class AuditorFinalizeOrchestrator implements AutoCloseable {
   /**
    * Creates an orchestrator.
    *
-   * @param auditorProps the properties used by the ScalarDL Auditor
-   * @param clientProps the properties used by the ScalarDL Client
+   * @param props the settings for connecting to the Auditor server, in addition to the properties
+   *     used by the ScalarDL Auditor
    * @param checkpointDir root directory for checkpoint state
    * @return a new orchestrator instance
-   * @throws IOException if the client configuration cannot be loaded
    * @throws ScalarDlCleanupException if the configuration is not supported
    */
-  // TODO: unify auditorProps and clientProps into a single Properties so callers only supply one
-  //  configuration. We plan to make AuditorClient buildable without requiring additional client
-  //  configuration as much as possible.
-  public static AuditorFinalizeOrchestrator create(
-      Properties auditorProps, Properties clientProps, Path checkpointDir) throws IOException {
+  public static AuditorFinalizeOrchestrator create(Properties props, Path checkpointDir) {
     DistributedStorageAdmin admin = null;
     DistributedStorage storage = null;
     AuditorClient auditorClient = null;
     try {
-      DatabaseConfig databaseConfig = new DatabaseConfig(auditorProps);
+      DatabaseConfig databaseConfig = new DatabaseConfig(props);
       StorageValidator.validate(databaseConfig);
-      StorageFactory storageFactory = StorageFactory.create(auditorProps);
+      StorageFactory storageFactory = StorageFactory.create(props);
       admin = storageFactory.getStorageAdmin();
       storage = storageFactory.getStorage();
 
-      ClientConfig clientConfig = new ClientConfig(clientProps);
-      if (clientConfig.getAuditorTargetConfig() == null) {
-        throw new IllegalArgumentException("Auditor target configuration is missing.");
-      }
-      auditorClient = new AuditorClient(clientConfig.getAuditorTargetConfig());
-
-      String baseNamespace =
-          auditorProps.getProperty(
-              AuditorInternalValues.AUDITOR_NAMESPACE_PROPERTY,
-              AuditorInternalValues.DEFAULT_BASE_NAMESPACE);
+      AuditorFinalizeConfig config = new AuditorFinalizeConfig(props);
+      auditorClient = new AuditorClient(config.getAuditorTargetConfig());
 
       ResumableScannerFactory scannerFactory = new ResumableScannerFactory(databaseConfig);
       return new AuditorFinalizeOrchestrator(
-          admin, storage, auditorClient, scannerFactory, checkpointDir, baseNamespace);
+          admin, storage, auditorClient, scannerFactory, checkpointDir, config.getBaseNamespace());
     } catch (Exception e) {
       if (auditorClient != null) {
         auditorClient.shutdown();

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfigTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfigTest.java
@@ -1,0 +1,177 @@
+package com.scalar.dl.tools.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.dl.client.config.ClientConfig;
+import com.scalar.dl.ledger.config.TargetConfig;
+import com.scalar.dl.tools.common.AuditorInternalValues;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AuditorFinalizeConfigTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void buildAuditorTargetConfig_nothingGiven_shouldUseDefaults() {
+    // Arrange
+    Properties props = new Properties();
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetHost()).isEqualTo(AuditorFinalizeConfig.DEFAULT_AUDITOR_HOST);
+    assertThat(config.getTargetPort()).isEqualTo(AuditorFinalizeConfig.DEFAULT_AUDITOR_PORT);
+    assertThat(config.getTargetPrivilegedPort())
+        .isEqualTo(AuditorFinalizeConfig.DEFAULT_AUDITOR_PRIVILEGED_PORT);
+    assertThat(config.isTargetTlsEnabled())
+        .isEqualTo(AuditorFinalizeConfig.DEFAULT_AUDITOR_TLS_ENABLED);
+    assertThat(config.getTargetTlsCaRootCert()).isNull();
+    assertThat(config.getTargetTlsOverrideAuthority()).isNull();
+    assertThat(config.getGrpcClientConfig().getDeadlineDurationMillis())
+        .isEqualTo(AuditorFinalizeConfig.DEFAULT_GRPC_DEADLINE_MS);
+  }
+
+  @Test
+  void buildAuditorTargetConfig_hostGiven_shouldUseIt() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_HOST, "auditor.example.com");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetHost()).isEqualTo("auditor.example.com");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_portsGiven_shouldUseThem() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_PORT, "50051");
+    props.setProperty(ClientConfig.AUDITOR_PRIVILEGED_PORT, "50052");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetPort()).isEqualTo(50051);
+    assertThat(config.getTargetPrivilegedPort()).isEqualTo(50052);
+  }
+
+  @Test
+  void buildAuditorTargetConfig_tlsEnabledGiven_shouldUseIt() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_TLS_ENABLED, "true");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.isTargetTlsEnabled()).isTrue();
+  }
+
+  @Test
+  void buildAuditorTargetConfig_tlsCaRootCertPemGiven_shouldUseIt() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PEM, "cert-from-pem");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetTlsCaRootCert()).isEqualTo("cert-from-pem");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_tlsCaRootCertPathGiven_shouldReadCertFromFile() throws IOException {
+    // Arrange
+    Path certFile = tempDir.resolve("ca.pem");
+    Files.write(certFile, "cert-from-file".getBytes(StandardCharsets.UTF_8));
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PATH, certFile.toString());
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetTlsCaRootCert()).isEqualTo("cert-from-file");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_tlsCaRootCertPemAndPathGiven_shouldPreferPem() throws IOException {
+    // Arrange
+    Path certFile = tempDir.resolve("ca.pem");
+    Files.write(certFile, "cert-from-file".getBytes(StandardCharsets.UTF_8));
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PEM, "cert-from-pem");
+    props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PATH, certFile.toString());
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetTlsCaRootCert()).isEqualTo("cert-from-pem");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_tlsOverrideAuthorityGiven_shouldUseIt() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_TLS_OVERRIDE_AUTHORITY, "auditor.test");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetTlsOverrideAuthority()).isEqualTo("auditor.test");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_grpcDeadlineSetInProps_shouldStillUseFixedDeadline() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.GRPC_DEADLINE_DURATION_MILLIS, "12345");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getGrpcClientConfig().getDeadlineDurationMillis())
+        .isEqualTo(AuditorFinalizeConfig.DEFAULT_GRPC_DEADLINE_MS);
+  }
+
+  @Test
+  void getBaseNamespace_notSetGiven_shouldReturnDefault() {
+    // Arrange
+    Properties props = new Properties();
+
+    // Act
+    AuditorFinalizeConfig config = new AuditorFinalizeConfig(props);
+
+    // Assert
+    assertThat(config.getBaseNamespace()).isEqualTo(AuditorInternalValues.DEFAULT_BASE_NAMESPACE);
+  }
+
+  @Test
+  void getBaseNamespace_setGiven_shouldReturnConfiguredValue() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(AuditorInternalValues.AUDITOR_NAMESPACE_PROPERTY, "my_auditor");
+
+    // Act
+    AuditorFinalizeConfig config = new AuditorFinalizeConfig(props);
+
+    // Assert
+    assertThat(config.getBaseNamespace()).isEqualTo("my_auditor");
+  }
+}

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfigTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeConfigTest.java
@@ -6,7 +6,6 @@ import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.ledger.config.TargetConfig;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -34,6 +33,7 @@ class AuditorFinalizeConfigTest {
         .isEqualTo(AuditorFinalizeConfig.DEFAULT_AUDITOR_TLS_ENABLED);
     assertThat(config.getTargetTlsCaRootCert()).isNull();
     assertThat(config.getTargetTlsOverrideAuthority()).isNull();
+    assertThat(config.getTargetAuthorizationCredential()).isNull();
     assertThat(config.getGrpcClientConfig().getDeadlineDurationMillis())
         .isEqualTo(AuditorFinalizeConfig.DEFAULT_GRPC_DEADLINE_MS);
   }
@@ -96,7 +96,7 @@ class AuditorFinalizeConfigTest {
   void buildAuditorTargetConfig_tlsCaRootCertPathGiven_shouldReadCertFromFile() throws IOException {
     // Arrange
     Path certFile = tempDir.resolve("ca.pem");
-    Files.write(certFile, "cert-from-file".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(certFile, "cert-from-file");
     Properties props = new Properties();
     props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PATH, certFile.toString());
 
@@ -111,7 +111,7 @@ class AuditorFinalizeConfigTest {
   void buildAuditorTargetConfig_tlsCaRootCertPemAndPathGiven_shouldPreferPem() throws IOException {
     // Arrange
     Path certFile = tempDir.resolve("ca.pem");
-    Files.write(certFile, "cert-from-file".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(certFile, "cert-from-file");
     Properties props = new Properties();
     props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PEM, "cert-from-pem");
     props.setProperty(ClientConfig.AUDITOR_TLS_CA_ROOT_CERT_PATH, certFile.toString());
@@ -134,6 +134,19 @@ class AuditorFinalizeConfigTest {
 
     // Assert
     assertThat(config.getTargetTlsOverrideAuthority()).isEqualTo("auditor.test");
+  }
+
+  @Test
+  void buildAuditorTargetConfig_authorizationCredentialGiven_shouldUseIt() {
+    // Arrange
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.AUDITOR_AUTHORIZATION_CREDENTIAL, "Bearer token");
+
+    // Act
+    TargetConfig config = AuditorFinalizeConfig.buildAuditorTargetConfig(props);
+
+    // Assert
+    assertThat(config.getTargetAuthorizationCredential()).isEqualTo("Bearer token");
   }
 
   @Test

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestratorTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/AuditorFinalizeOrchestratorTest.java
@@ -21,6 +21,7 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scanner;
 import com.scalar.db.config.DatabaseConfig;
 import com.scalar.db.service.StorageFactory;
+import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.client.service.AuditorClient;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.CompletionToken;
@@ -85,12 +86,11 @@ class AuditorFinalizeOrchestratorTest {
   @Test
   void create_nonCosmosStorageGiven_shouldThrowScalarDlCleanupException() {
     // Arrange
-    Properties auditorProps = new Properties();
-    auditorProps.setProperty(DatabaseConfig.STORAGE, "cassandra");
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cassandra");
 
     // Act & Assert
-    assertThatThrownBy(
-            () -> AuditorFinalizeOrchestrator.create(auditorProps, new Properties(), tempDir))
+    assertThatThrownBy(() -> AuditorFinalizeOrchestrator.create(props, tempDir))
         .isInstanceOf(ScalarDlCleanupException.class)
         .hasMessageContaining("not supported");
   }
@@ -98,14 +98,9 @@ class AuditorFinalizeOrchestratorTest {
   @Test
   void create_cosmosStorageGiven_shouldNotThrow() {
     // Arrange
-    Properties auditorProps = new Properties();
-    auditorProps.setProperty(DatabaseConfig.STORAGE, "cosmos");
-    Properties clientProps = new Properties();
-    clientProps.setProperty("scalar.dl.client.mode", "client");
-    clientProps.setProperty("scalar.dl.client.entity.id", "test-entity");
-    clientProps.setProperty("scalar.dl.client.authentication.method", "hmac");
-    clientProps.setProperty("scalar.dl.client.entity.identity.hmac.secret_key", "test-secret");
-    clientProps.setProperty("scalar.dl.client.auditor.enabled", "true");
+    Properties props = new Properties();
+    props.setProperty(DatabaseConfig.STORAGE, "cosmos");
+    props.setProperty(ClientConfig.AUDITOR_HOST, "auditor.example.com");
 
     StorageFactory storageFactory = mock(StorageFactory.class);
     when(storageFactory.getStorageAdmin()).thenReturn(mock(DistributedStorageAdmin.class));
@@ -118,7 +113,7 @@ class AuditorFinalizeOrchestratorTest {
           .thenReturn(storageFactory);
 
       // Act & Assert
-      assertThatCode(() -> AuditorFinalizeOrchestrator.create(auditorProps, clientProps, tempDir))
+      assertThatCode(() -> AuditorFinalizeOrchestrator.create(props, tempDir))
           .doesNotThrowAnyException();
     }
   }

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -34,9 +34,9 @@ pf_wait 40051 40052
 # config secrets so the tool sees exactly the ScalarDB configuration each server uses.
 kubectl -n ledger-e2e  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
 kubectl -n auditor-e2e get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
-# finalize-auditor additionally needs ScalarDL client properties to reach the Auditor server's
+# finalize-auditor additionally needs some ScalarDL client properties to reach the Auditor server's
 # privileged port. The leading newline guards against the Secret value lacking a trailing newline.
-{ echo; cat "$HERE/client.properties"; } >> "$auditor_props"
+{ echo; echo "scalar.dl.client.auditor.host=127.0.0.1"; } >> "$auditor_props"
 
 # Run one cleanup subcommand and echo its stdout JSON. On failure, surface the captured stderr and
 # return non-zero so the caller's `set -e` aborts. Usage: run_tool <subcommand> [args...]

--- a/scalardl-cleanup/cli/src/main/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommand.java
+++ b/scalardl-cleanup/cli/src/main/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommand.java
@@ -3,7 +3,6 @@ package com.scalar.dl.tools.cli;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.dl.tools.cleanup.AuditorFinalizeOrchestrator;
 import com.scalar.dl.tools.cleanup.RequestProofCleanupOrchestrator;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
 import picocli.CommandLine.Command;
@@ -32,10 +31,10 @@ public class AuditorFinalizeRecordsCommand extends AbstractToolCommand {
   @Override
   protected Integer execute(Properties props, Path checkpointDir) throws Exception {
     // The single --properties file serves as both the Auditor's database configuration and the
-    // ScalarDL client configuration used to reach the Auditor server.
+    // source of the Auditor server connection used to reach the privileged RecoverAssetLock RPC.
     String auditorToken;
     try (AuditorFinalizeOrchestrator orchestrator =
-        createFinalizeOrchestrator(props, props, checkpointDir)) {
+        createFinalizeOrchestrator(props, checkpointDir)) {
       auditorToken = orchestrator.execute();
     }
 
@@ -54,9 +53,8 @@ public class AuditorFinalizeRecordsCommand extends AbstractToolCommand {
   }
 
   @VisibleForTesting
-  AuditorFinalizeOrchestrator createFinalizeOrchestrator(
-      Properties auditorProps, Properties clientProps, Path checkpointDir) throws IOException {
-    return AuditorFinalizeOrchestrator.create(auditorProps, clientProps, checkpointDir);
+  AuditorFinalizeOrchestrator createFinalizeOrchestrator(Properties props, Path checkpointDir) {
+    return AuditorFinalizeOrchestrator.create(props, checkpointDir);
   }
 
   @VisibleForTesting

--- a/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommandTest.java
+++ b/scalardl-cleanup/cli/src/test/java/com/scalar/dl/tools/cli/AuditorFinalizeRecordsCommandTest.java
@@ -65,7 +65,7 @@ public class AuditorFinalizeRecordsCommandTest {
         new AuditorFinalizeRecordsCommand() {
           @Override
           AuditorFinalizeOrchestrator createFinalizeOrchestrator(
-              Properties auditorProps, Properties clientProps, Path checkpointDir) {
+              Properties props, Path checkpointDir) {
             return finalizer;
           }
 
@@ -104,7 +104,7 @@ public class AuditorFinalizeRecordsCommandTest {
         new AuditorFinalizeRecordsCommand() {
           @Override
           AuditorFinalizeOrchestrator createFinalizeOrchestrator(
-              Properties auditorProps, Properties clientProps, Path checkpointDir) {
+              Properties props, Path checkpointDir) {
             return finalizer;
           }
 
@@ -142,7 +142,7 @@ public class AuditorFinalizeRecordsCommandTest {
         new AuditorFinalizeRecordsCommand() {
           @Override
           AuditorFinalizeOrchestrator createFinalizeOrchestrator(
-              Properties auditorProps, Properties clientProps, Path checkpointDir) {
+              Properties props, Path checkpointDir) {
             return finalizer;
           }
 


### PR DESCRIPTION
## Description

This PR simplifies the configuration of the `finalize-auditor`. Because the command communicates with the Auditor server, it requires some client properties. Currently, the command requires a full client configuration, but it's too much. This PR identifies what's really needed and makes the required configuration minimal.

## Related issues and/or PRs

We should test this change with:

- #62 

## Changes made

- Unify `AuditorFinalizeOrchestrator.create()` to take a single `Properties` instead of separate Auditor and client properties.
- Add `AuditorFinalizeConfig` to resolve the Auditor server connection (host, ports, TLS) and base namespace from that single properties file.
- Build `AuditorClient` from a connection target only, dropping the need for a full ScalarDL client configuration.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A