### PR TITLE
Run the cleanup commands from the manifests in the E2E test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,7 +7,9 @@ name: E2E
 #      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
 #   2. Upgrade both servers in place to the new version (which exposes the privileged
 #      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the three operator-facing cleanup subcommands against the upgraded cluster:
+#   3. Run the three operator-facing cleanup subcommands against the upgraded cluster, deployed the
+#      way an operator deploys them: as Kubernetes Jobs from scalardl-cleanup/manifests, in the
+#      documented apply order (so the deployment procedure is under test too).
 #        finalize-ledger      -> emits the Ledger completion token
 #        finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and
 #                                cleans up request_proof; emits the Auditor completion token
@@ -49,6 +51,11 @@ jobs:
       GHCR_USER: ${{ github.repository_owner }}
       # Records generated per category (committed / stranded write / stranded read).
       RECORD_COUNT: 5
+      # Tag of the cleanup image built from this checkout and loaded into minikube. The manifests
+      # resolve the image as ghcr.io/scalar-labs/scalardl-cleanup:${CLEANUP_VERSION}; any tag other
+      # than "latest" keeps the default imagePullPolicy at IfNotPresent, so the locally loaded image
+      # is used and nothing is pulled from ghcr.
+      CLEANUP_VERSION: dev
     steps:
       - uses: actions/checkout@v4
 
@@ -61,15 +68,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build the cleanup CLI
+      - name: Build the cleanup container image
+        # The cleanup commands run from the manifests, which deploy the container image, so build it
+        # here with the same :cli:docker task the release workflows use.
         # GPR_* let Gradle pull the ScalarDL artifacts from GitHub Packages.
         env:
           GPR_USERNAME: ${{ github.repository_owner }}
           GPR_PASSWORD: ${{ secrets.CR_PAT }}
-        run: |
-          set -euo pipefail
-          ./gradlew :cli:installDist
-          echo "CLEANUP=$(pwd)/cli/build/install/scalardl-cleanup/bin/scalardl-cleanup" >> "$GITHUB_ENV"
+        run: ./gradlew :cli:docker -PdockerVersion="$CLEANUP_VERSION"
 
       - name: Install Azure Cosmos DB Shell
         # Used by run-cleanup.sh to count rows directly in Cosmos for the post-cleanup reclamation
@@ -104,6 +110,10 @@ jobs:
         with:
           cpus: '4'
           memory: '8192'
+
+      - name: Load the cleanup image into minikube
+        # The image was built into the runner's Docker daemon, which the minikube node cannot see.
+        run: minikube image load "ghcr.io/scalar-labs/scalardl-cleanup:$CLEANUP_VERSION"
 
       - name: Deploy ScalarDL (old version) + load schema
         env:
@@ -177,7 +187,7 @@ jobs:
           SCALARDL_VERSION: ${{ env.SCALARDL_NEW_VERSION }}
         run: ./ci/e2e/manage-cluster.sh upgrade
 
-      - name: Run the cleanup commands
+      - name: Run the cleanup commands as Kubernetes Jobs
         run: ./ci/e2e/run-cleanup.sh
 
       - name: Verify post-cleanup consistency
@@ -222,6 +232,8 @@ jobs:
           for ns in ledger-e2e auditor-e2e; do
             echo "===== namespace: $ns ====="
             kubectl -n "$ns" get all -o wide
+            # `get all` omits PVCs; the cleanup Jobs cannot start without their checkpoint volume.
+            kubectl -n "$ns" get pvc -o wide
             kubectl -n "$ns" get events --sort-by=.lastTimestamp
             kubectl -n "$ns" describe pods
             for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
@@ -231,10 +243,6 @@ jobs:
           done
           echo "===== port-forward logs ====="
           cat /tmp/pf-*.log 2>/dev/null || true
-          echo "===== cleanup tool stderr logs ====="
-          for f in "$RUNNER_TEMP"/finalize-ledger.err "$RUNNER_TEMP"/finalize-auditor.err "$RUNNER_TEMP"/cleanup-coordinator.err; do
-            [ -f "$f" ] && { echo "----- $f -----"; cat "$f"; }
-          done
 
       - name: Drop Cosmos schema
         if: always()

--- a/scalardl-cleanup/ci/e2e/common.sh
+++ b/scalardl-cleanup/ci/e2e/common.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Shared definitions for the E2E scripts. Source it:
+#
+#   source ci/e2e/common.sh
+#
+# It holds the cluster facts both scripts must agree on -- namespaces, the Auditor's TLS SAN and
+# where its cert lives -- plus the kubectl helpers they both use.
+
+# K8s namespaces. Exported because the manifests refer to them as ${LEDGER_NS} / ${AUDITOR_NS}.
+export LEDGER_NS="ledger-e2e"
+export AUDITOR_NS="auditor-e2e"
+
+# CN/SAN of the disposable Auditor server cert, and the directory manage-cluster.sh generates it
+# into. A client that reaches the Auditor under a different name has to pin this as the TLS authority.
+export AUDITOR_TLS_SAN="auditor.e2e.scalar-labs.com"
+CERTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+
+# require_vars VAR...
+# Abort unless every named environment variable is set and non-empty.
+require_vars() {
+  for v in "$@"; do
+    if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
+  done
+}
+
+# Dump everything useful about a namespace's workloads, then fail.
+diag_and_die() {
+  local ns="$1" msg="$2"
+  echo "::error::${msg}"
+  echo "----- pods (${ns}) -----";            kubectl -n "$ns" get pods -o wide || true
+  echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
+  echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
+  echo "----- logs (${ns}) -----"
+  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null || true); do
+    echo "### $p"
+    kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
+  done
+  exit 1
+}
+
+# Poll a Job for complete/failed (kubectl wait --for=complete hangs on failure),
+# printing diagnostics inline the moment it fails or times out.
+wait_for_job() {
+  local ns="$1" job="$2" timeout="${3:-300}" waited=0
+  while true; do
+    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q True; then
+      echo "job/$job complete"; return 0
+    fi
+    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q True; then
+      diag_and_die "$ns" "job/$job failed"
+    fi
+    if (( waited >= timeout )); then
+      diag_and_die "$ns" "job/$job did not complete within ${timeout}s"
+    fi
+    sleep 5; waited=$((waited + 5))
+  done
+}

--- a/scalardl-cleanup/ci/e2e/manage-cluster.sh
+++ b/scalardl-cleanup/ci/e2e/manage-cluster.sh
@@ -35,10 +35,9 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# K8s namespaces.
-export LEDGER_NS="ledger-e2e"
-export AUDITOR_NS="auditor-e2e"
+# Namespaces, the Auditor TLS SAN, CERTS_DIR, and the kubectl helpers (require_vars,
+# wait_for_job, diag_and_die) live here so run-cleanup.sh sees exactly the same values.
+source "$HERE/common.sh"
 
 SCALARDL_VERSION_EXPLICIT="${SCALARDL_VERSION:+yes}"   # "yes" if set and non-empty, else ""
 
@@ -58,9 +57,6 @@ export SL_JOB_SUFFIX=""
 export SL_LEDGER_ARGS='["--config", "/config/database.properties", "--coordinator"]'
 export SL_AUDITOR_ARGS='["--config", "/config/database.properties"]'
 
-export AUDITOR_TLS_SAN="auditor.e2e.scalar-labs.com"
-CERTS_DIR="$HERE/certs"
-
 # Give envsubst an explicit variable list so it substitutes ONLY these placeholders.
 # Without a list, envsubst expands EVERY $VAR in the manifests, which would wrongly
 # rewrite unrelated shell-style tokens (e.g. a literal $@ in a container command).
@@ -69,14 +65,6 @@ SUBST_VARS+='${COSMOS_URI} ${COSMOS_KEY} ${SERVERS_HMAC_SECRET} ${HMAC_CIPHER_KE
 SUBST_VARS+='${SL_JOB_SUFFIX} ${SL_LEDGER_ARGS} ${SL_AUDITOR_ARGS}'
 
 render() { envsubst "$SUBST_VARS" < "$HERE/$1"; }
-
-# require_vars VAR...
-# Abort unless every named environment variable is set and non-empty.
-require_vars() {
-  for v in "$@"; do
-    if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
-  done
-}
 
 # Generate a disposable self-signed cert/key for the Auditor server TLS. Reused if it already exists,
 # so re-running deploy does not rotate the cert out from under a running Auditor pod (`clean` drops it
@@ -137,21 +125,6 @@ upgrade() {
   grpc_health_checks " after upgrade to $SCALARDL_VERSION"
 }
 
-# Dump everything useful about a namespace's workloads, then fail.
-diag_and_die() {
-  local ns="$1" msg="$2"
-  echo "::error::${msg}"
-  echo "----- pods (${ns}) -----";            kubectl -n "$ns" get pods -o wide || true
-  echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
-  echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
-  echo "----- logs (${ns}) -----"
-  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null || true); do
-    echo "### $p"
-    kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
-  done
-  exit 1
-}
-
 # Health-check the Ledger (plaintext) and Auditor (TLS, verified against the SAN), aborting with
 # diagnostics on failure. $1 is an optional message suffix (e.g. " after upgrade to <version>").
 grpc_health_checks() {
@@ -166,24 +139,6 @@ grpc_health_checks() {
       -tls -tls-ca-cert=/etc/scalardl-tls/tls.crt -tls-server-name="$AUDITOR_TLS_SAN"; then
     diag_and_die "$AUDITOR_NS" "Auditor gRPC health check failed${suffix}"
   fi
-}
-
-# Poll a Job for complete/failed (kubectl wait --for=complete hangs on failure),
-# printing diagnostics inline the moment it fails or times out.
-wait_for_job() {
-  local ns="$1" job="$2" timeout="${3:-300}" waited=0
-  while true; do
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q True; then
-      echo "job/$job complete"; return 0
-    fi
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q True; then
-      diag_and_die "$ns" "job/$job failed"
-    fi
-    if (( waited >= timeout )); then
-      diag_and_die "$ns" "job/$job did not complete within ${timeout}s"
-    fi
-    sleep 5; waited=$((waited + 5))
-  done
 }
 
 # Wait for a Deployment to become available, with inline diagnostics on timeout.

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -60,11 +60,14 @@ upsert_credentials_secret() {
 }
 
 # Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
-# re-run of this script would otherwise fail on apply.
+# re-run of this script would otherwise fail on apply. As in manage-cluster.sh, give envsubst an
+# explicit variable list so it substitutes ONLY these placeholders and never rewrites a literal
+# $VAR that later lands in a manifest. The tokens are unset until Step 3 and expand to empty, but
+# the finalize manifests never reference them.
 # Usage: apply_job <namespace> <job> <manifest>
 apply_job() {
   kubectl -n "$1" delete "job/$2" --ignore-not-found
-  envsubst < "$3" | kubectl -n "$1" apply -f -
+  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
 }
 
 # Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -1,83 +1,99 @@
 #!/usr/bin/env bash
 #
-# Run the three ScalarDL Cleanup commands against the deployed E2E cluster and assert each
-# one succeeds.
+# Run the three ScalarDL Cleanup commands against the deployed E2E cluster the way an operator does:
+#
+#   Step 1 (Ledger AD)  credentials Secret -> checkpoint PVC -> ConfigMap -> finalize-ledger Job
+#   Step 2 (Auditor AD) credentials Secret -> checkpoint PVC -> ConfigMap (+ TLS optional settings)
+#                       -> finalize-auditor Job
+#   Step 3 (Ledger AD)  cleanup-coordinator Job, with both completion tokens
 #
 # Expects in the environment:
-#   CLEANUP        path to the scalardl-cleanup binary (set by the workflow)
-#   COSMOSDB_SHELL path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
-#   RUNNER_TEMP    scratch directory for checkpoints and per-command stderr logs
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RUNNER_TEMP      scratch directory for the rendered ConfigMaps
+#   RECORD_COUNT     number of records populated per category
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 
 set -euo pipefail
 
-for v in CLEANUP COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT; do
-  if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
-done
-
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/port-forward.sh"
-# Tear down the background port-forwards on exit (success or failure) so a standalone or
-# interrupted run leaves no dangling kubectl processes.
-trap pf_reset EXIT
+source "$HERE/common.sh"
 
-ckpt="$RUNNER_TEMP/checkpoint"
+require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
+
+# The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
+# passed to kubectl instead. LEDGER_NS / AUDITOR_NS / AUDITOR_TLS_SAN come from common.sh exported.
+export CLEANUP_VERSION
+
+MANIFESTS="$HERE/../../manifests"
+
+# Working copy of the manifests, one directory per administrative domain as in the source tree.
+work="$RUNNER_TEMP/manifests"
+rm -rf "$work"
+mkdir -p "$work"
+cp -R "$MANIFESTS/ledger-ad" "$MANIFESTS/auditor-ad" "$work/"
+
 ledger_props="$RUNNER_TEMP/ledger.properties"
 auditor_props="$RUNNER_TEMP/auditor.properties"
-
-# finalize-auditor is the only command that talks to a server.
-pf_reset
-pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
-pf_wait 40051 40052
-
-# The tool takes the servers' properties files as-is. Pull them straight from the deployed
-# config secrets so the tool sees exactly the ScalarDB configuration each server uses.
-kubectl -n ledger-e2e  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
-kubectl -n auditor-e2e get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
-
-# finalize-auditor additionally needs some ScalarDL client properties to reach the Auditor server's
-# privileged port. The leading newline guards against the Secret value lacking a trailing newline.
-# TLS is enabled on the Auditor, so the tool connects with TLS (tls.enabled), trusts the self-signed
-# cert (ca_root_cert_path) and pins its SAN (override_authority) since it connects through a 127.0.0.1
-# port-forward. The SAN must match AUDITOR_TLS_SAN in manage-cluster.sh.
-{
-  echo
-  echo "scalar.dl.client.auditor.host=127.0.0.1"
-  echo "scalar.dl.client.auditor.tls.enabled=true"
-  echo "scalar.dl.client.auditor.tls.ca_root_cert_path=$HERE/certs/auditor.crt"
-  echo "scalar.dl.client.auditor.tls.override_authority=auditor.e2e.scalar-labs.com"
-} >> "$auditor_props"
-
-# Run one cleanup subcommand and echo its stdout JSON. On failure, surface the captured stderr and
-# return non-zero so the caller's `set -e` aborts. Usage: run_tool <subcommand> [args...]
-run_tool() {
-  local sub="$1" out
-  if ! out=$("$CLEANUP" "$@" --checkpoint-dir "$ckpt" 2>"$RUNNER_TEMP/$sub.err"); then
-    cat "$RUNNER_TEMP/$sub.err" >&2
-    echo "::error::$sub failed" >&2
-    return 1
-  fi
-  printf '%s\n' "$out"
-}
-
-# Extract a non-empty completion token from a finalize command's JSON, or fail.
-completion_token() {
-  local sub="$1" json="$2" token
-  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
-  [ -n "$token" ] || { echo "::error::$sub emitted no completion token"; return 1; }
-  printf '%s\n' "$token"
-}
 
 # Read a single property value from a properties file.
 # Usage: read_prop_value <file> <key>
 read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
 
-# Count items in a container, authenticating with the account endpoint/key from the given properties.
-# Usage: count_cosmos_items <properties> <database> <container>
+# Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
+# from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
+# and keeps this script free of secrets of its own.
+kubectl -n "$LEDGER_NS"  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
+kubectl -n "$AUDITOR_NS" get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
+ledger_uri=$(read_prop_value "$ledger_props" scalar.db.contact_points)
+ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
+auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
+auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
+
+# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
+# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
+# Usage: upsert_credentials_secret <namespace> <cosmos-key>
+upsert_credentials_secret() {
+  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
+    --from-literal=SCALAR_DB_PASSWORD="$2" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
+# re-run of this script would otherwise fail on apply.
+# Usage: apply_job <namespace> <job> <manifest>
+apply_job() {
+  kubectl -n "$1" delete "job/$2" --ignore-not-found
+  envsubst < "$3" | kubectl -n "$1" apply -f -
+}
+
+# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
+# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
+# JSON line out of the log4j lines around it.
+# Usage: read_job_output_json <namespace> <job>
+read_job_output_json() {
+  local ns="$1" job="$2" pod json
+  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
+    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
+  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
+  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
+  printf '%s\n' "$json"
+}
+
+# Extract a non-empty completion token from a finalize command's JSON output, or fail.
+# Usage: extract_completion_token <command-name> <json>
+extract_completion_token() {
+  local name="$1" json="$2" token
+  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
+  [ -n "$token" ] || { echo "::error::$name emitted no completion token" >&2; return 1; }
+  printf '%s\n' "$token"
+}
+
+# Count items in a container, authenticating with the given account endpoint and key.
+# Usage: count_cosmos_items <endpoint> <key> <database> <container>
 count_cosmos_items() {
-  local properties="$1" database="$2" container="$3" endpoint account_key output count
-  endpoint=$(read_prop_value "$properties" scalar.db.contact_points)
-  account_key=$(read_prop_value "$properties" scalar.db.password)
+  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
   output=$("$COSMOSDB_SHELL" <<EOF
 connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
 cd ${database}
@@ -98,27 +114,79 @@ EOF
   printf '%s\n' "$count"
 }
 
-echo "== Execute finalize-ledger =="
-ledger_out=$(run_tool finalize-ledger --properties "$ledger_props")
-echo "$ledger_out"
-token_l=$(completion_token finalize-ledger "$ledger_out")
+# --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
+echo "== Step 1: finalize-ledger =="
 
-echo "== Execute finalize-auditor =="
-rp_before=$(count_cosmos_items "$auditor_props" auditor request_proof)
-auditor_out=$(run_tool finalize-auditor --properties "$auditor_props")
-echo "$auditor_out"
-token_a=$(completion_token finalize-auditor "$auditor_out")
-rp_after=$(count_cosmos_items "$auditor_props" auditor request_proof)
+# (a) Create the credentials Secret.
+upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+
+# (b) Create the checkpoint volume.
+kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
+
+# (c) Apply the ConfigMap, substituting contact_points first.
+sed "s|<cosmos-account-uri>|$ledger_uri|" \
+  "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
+kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
+
+# (d) Run the Job.
+apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
+wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
+ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
+echo "finalize-ledger output: $ledger_out"
+token_l=$(extract_completion_token finalize-ledger "$ledger_out")
+
+# --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
+echo "== Step 2: finalize-auditor =="
+
+# (a) Create the credentials Secret.
+upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+
+# (b) Create the checkpoint volume.
+kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
+
+# (c) Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
+# serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
+sed -E \
+  -e "s|<cosmos-account-uri>|$auditor_uri|" \
+  -e "s|<auditor-host>|auditor|" \
+  -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
+  -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
+  "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
+kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
+
+# Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
+# Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
+kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
+  --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# (d) Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
+# timeout.
+rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
+wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
+auditor_out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
+echo "finalize-auditor output: $auditor_out"
+token_a=$(extract_completion_token finalize-auditor "$auditor_out")
+rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
 echo "request_proof rows: before=$rp_before after=$rp_after"
 [ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
 
-echo "== Execute cleanup-coordinator =="
-cs_before=$(count_cosmos_items "$ledger_props" coordinator state)
-coord_out=$(run_tool cleanup-coordinator --properties "$ledger_props" --ledger-token "$token_l" --auditor-token "$token_a")
-echo "$coord_out"
+# --- Step 3 (Ledger AD): cleanup-coordinator ---------------------------------------------------
+echo "== Step 3: cleanup-coordinator =="
+
+# The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
+export LEDGER_TOKEN="$token_l" AUDITOR_TOKEN="$token_a"
+
+cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
+wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
+coord_out=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
+echo "cleanup-coordinator output: $coord_out"
 [ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
   || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
-cs_after=$(count_cosmos_items "$ledger_props" coordinator state)
+
+cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
 # Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
 # so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
 # writing coordinator.state rows after the boundary, which survive and are not counted here.


### PR DESCRIPTION
## Description

This PR updates the E2E test to use manifest files added in #64 to simulate a real operation.

The operations in run-cleanup.sh follow `manifests/README.md`. I'm planning to create a document of the tool based on `manifests/README.md`, so please review it again. The E2E test updated in this PR verifies the operations.

## Related issues and/or PRs

Depends on:

- #64 

## Changes made

- Deploy the three cleanup commands as Jobs from manifests/.
- Extract the shared namespaces, Auditor TLS SAN, and kubectl helpers into ci/e2e/common.sh, used by both manage-cluster.sh and run-cleanup.sh.
- Drop the port-forward and local checkpoint directory from run-cleanup.sh, since the Jobs reach the Auditor in-cluster and checkpoint on the PVC.
- Dump PVCs in the failure diagnostics and remove the now-unused per-command stderr files.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A