### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
-      - dependency-name: "com.diffplug.spotless"
-      - dependency-name: "com.google.errorprone:*"
-      - dependency-name: "com.github.spotbugs:*"
 
   # For GitHub Actions, update all actions on the default branch
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # For Gradle, update dependencies and plugins to the latest non-major version
+  - package-ecosystem: "gradle"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    directory: "/scalardl-cleanup"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "com.diffplug.spotless"
+      - dependency-name: "com.google.errorprone:*"
+      - dependency-name: "com.github.spotbugs:*"
+
+  # For GitHub Actions, update all actions on the default branch
+  - package-ecosystem: "github-actions"
+    groups:
+      actions on branch master:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

This PR adds a Dependabot configuration to this repository, which has had none so far. It keeps the Gradle dependencies and the GitHub Actions used by the workflows up to date automatically, following the same policy as the ScalarDL repositories.

## Related issues and/or PRs

N/A

## Changes made

- Add `.github/dependabot.yml`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A