### PR TITLE
Extend the E2E test as suggested in the review on #55

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,16 +5,26 @@ name: E2E
 #
 #   1. Deploy ScalarDL Ledger + Auditor at the old version on minikube against a real Cosmos DB,
 #      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
-#   2. Upgrade both servers in place to the new version (which exposes the privileged
-#      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the three operator-facing cleanup subcommands against the upgraded cluster, deployed the
+#   2. Assert that finalize-auditor refuses to run against that old version: the privileged
+#      RecoverAssetLock RPC does not exist there, and the operator must be told to upgrade.
+#   3. Upgrade both servers in place to the new version (which exposes that RPC).
+#   4. Run the three operator-facing cleanup subcommands against the upgraded cluster, deployed the
 #      way an operator deploys them: as Kubernetes Jobs from scalardl-cleanup/manifests, in the
 #      documented apply order (so the deployment procedure is under test too).
 #        finalize-ledger      -> emits the Ledger completion token
 #        finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and
 #                                cleans up request_proof; emits the Auditor completion token
 #        cleanup-coordinator  -> deletes the settled coordinator.state records
-#   4. Assert, at the ScalarDL application layer, that every existing asset is writable, readable,
+#      Every command is interrupted midway (its Pod is force-deleted) and then re-applied with the
+#      same checkpoint volume, so the resumed run has to reach the same result -- the same completion
+#      token, the same rows deleted -- as an uninterrupted one. Re-running a finished command must
+#      change nothing at all.
+#   5. Commit new traffic in between, once both guarantee timestamps are captured but before the
+#      deletions run, and assert that none of the coordinator.state / request_proof records it
+#      creates are deleted (the Auditor's own transaction state purge is disabled, so the tool is
+#      the only thing that could delete them).
+#   6. Assert that cleanup-coordinator rejects the two completion tokens if they are swapped.
+#   7. Assert, at the ScalarDL application layer, that every existing asset is writable, readable,
 #      and passes validate-ledger.
 #
 # CI-only. Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
@@ -173,22 +183,62 @@ jobs:
       # Record what was populated. The verify step reads this back (single source of truth for the
       # asset ids), and it is uploaded as an artifact for inspection. strandedReadAssetIds are the
       # committed ids that also received a stranded READ lock (== committedAssetIds here).
+      # newTrafficAssetIds are committed later, after the cleanup commands captured their guarantee
+      # timestamps.
       - name: Write populated-assets metadata
         run: |
           jq -n --argjson n "$RECORD_COUNT" '{
             entityId: "e2e-client",
             committedAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
             strandedAssetIds: [range(0; $n) | "e2e-stranded-\(.)"],
-            strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"]
+            strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
+            newTrafficAssetIds: [range(0; $n) | "e2e-new-\(.)"]
           }' > "$RUNNER_TEMP/populated-assets.json"
+
+      - name: Reject finalize-auditor against the old-version Auditor
+        # Runs while the servers are still on the old version, which has no RecoverAssetLock RPC. The
+        # command must fail telling the operator to upgrade, not with a raw gRPC UNIMPLEMENTED error.
+        # It uses a checkpoint volume of its own, so it leaves nothing behind for the real run.
+        run: ./ci/e2e/run-cleanup.sh reject-old-auditor
 
       - name: Upgrade ScalarDL to the new version
         env:
           SCALARDL_VERSION: ${{ env.SCALARDL_NEW_VERSION }}
         run: ./ci/e2e/manage-cluster.sh upgrade
 
-      - name: Run the cleanup commands as Kubernetes Jobs
-        run: ./ci/e2e/run-cleanup.sh
+      - name: Run finalize-ledger, interrupted and resumed
+        run: ./ci/e2e/run-cleanup.sh finalize-ledger
+
+      - name: Interrupt finalize-auditor midway
+        # Kills the command after it has persisted its guarantee timestamp, with the Job's retries
+        # disabled so it stays down until the new traffic below has been committed.
+        run: ./ci/e2e/run-cleanup.sh interrupt-finalize-auditor
+
+      - name: Commit new traffic after the guarantee timestamps
+        # Both guarantee timestamps are already fixed at this point (finalize-ledger emitted its
+        # token, and the interrupted finalize-auditor persisted its own), so every record committed
+        # here falls outside the deletion window of every cleanup command and must survive.
+        run: |
+          set -euo pipefail
+          source ci/e2e/port-forward.sh
+          pf_reset
+          pf_start ledger-e2e  svc/ledger  50051:50051 50052:50052
+          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
+          pf_wait 50051 50052 40051 40052
+          props="ci/e2e/client.properties"
+          for i in $(seq 0 $((RECORD_COUNT - 1))); do
+            id="e2e-new-$i"
+            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+            if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
+              echo "::error::put-object on $id failed while committing the new traffic"; exit 1
+            fi
+          done
+
+      - name: Resume finalize-auditor
+        run: ./ci/e2e/run-cleanup.sh finalize-auditor
+
+      - name: Run cleanup-coordinator, interrupted and resumed
+        run: ./ci/e2e/run-cleanup.sh cleanup-coordinator
 
       - name: Verify post-cleanup consistency
         run: |
@@ -214,7 +264,7 @@ jobs:
             if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
               echo "::error::validate-ledger on $id failed after cleanup"; exit 1
             fi
-          done < <(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated")
+          done < <(jq -r '(.committedAssetIds + .strandedAssetIds + .newTrafficAssetIds)[]' "$populated")
           echo "Post-cleanup consistency verified."
 
       - name: Upload populated-assets

--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -8,6 +8,7 @@ import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.ScalarDlCleanupError;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
+import io.grpc.Status;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public final class LockFinalizer {
         AssetLockRecoveryRequest.newBuilder().setNamespace(namespace).setAssetId(assetId).build();
 
     for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
+      LockRecoveryResult rpcResult = recover(rpcRequest);
 
       if (rpcResult == LockRecoveryResult.SUCCEEDED || rpcResult == LockRecoveryResult.NOT_NEEDED) {
         return;
@@ -92,5 +93,25 @@ public final class LockFinalizer {
 
     throw new ScalarDlCleanupException(
         ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE, assetId, namespace, MAX_ATTEMPTS);
+  }
+
+  /**
+   * Issues the {@code RecoverAssetLock} RPC, translating an {@code UNIMPLEMENTED} status into an
+   * actionable error. An Auditor older than the release that introduced the RPC answers with that
+   * status, and the client SDK surfaces it as an opaque "UNIMPLEMENTED: Method not found" message
+   * with an unrelated status code, which gives the operator no hint that the fix is to upgrade the
+   * Auditor. Every other failure is left untouched.
+   */
+  private LockRecoveryResult recover(AssetLockRecoveryRequest rpcRequest) {
+    try {
+      return auditorClient.recover(rpcRequest);
+    } catch (RuntimeException e) {
+      // Status.fromThrowable walks the cause chain, so it finds the gRPC status the SDK wrapped.
+      // io.grpc comes from the ScalarDL client SDK, which speaks gRPC to the Auditor.
+      if (Status.fromThrowable(e).getCode() == Status.Code.UNIMPLEMENTED) {
+        throw new ScalarDlCleanupException(ScalarDlCleanupError.RECOVER_ASSET_LOCK_UNSUPPORTED, e);
+      }
+      throw e;
+    }
   }
 }

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -11,11 +11,15 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.Result;
 import com.scalar.dl.auditor.ordering.LockRecoveryResult;
+import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.AuditorClient;
+import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.ScalarDlCleanupError;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -92,6 +96,41 @@ class LockFinalizerTest {
     assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("RPC unavailable");
+  }
+
+  @Test
+  void execute_recoverThrowsUnimplementedGiven_shouldThrowUpgradeError() {
+    // Arrange — an Auditor without the RecoverAssetLock RPC answers UNIMPLEMENTED, which the client
+    // SDK rethrows as a ClientException wrapping the gRPC exception.
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenThrow(
+            new ClientException(
+                "UNIMPLEMENTED: Method not found: rpc.AuditorPrivileged/RecoverAssetLock",
+                new StatusRuntimeException(Status.UNIMPLEMENTED),
+                StatusCode.UNKNOWN_TRANSACTION_STATUS));
+
+    // Act & Assert — the operator is told to upgrade instead of seeing the raw gRPC message.
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(ScalarDlCleanupException.class)
+        .hasMessageContaining(ScalarDlCleanupError.RECOVER_ASSET_LOCK_UNSUPPORTED.buildCode())
+        .hasMessageContaining("upgrade the Auditor");
+    verify(auditorClient, times(1)).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_recoverThrowsOtherGrpcStatusGiven_shouldPropagateException() {
+    // Arrange — any status other than UNIMPLEMENTED is not an old-version symptom.
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenThrow(
+            new ClientException(
+                "UNAVAILABLE",
+                new StatusRuntimeException(Status.UNAVAILABLE),
+                StatusCode.UNKNOWN_TRANSACTION_STATUS));
+
+    // Act & Assert
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("UNAVAILABLE");
   }
 
   @Test

--- a/scalardl-cleanup/ci/e2e/common.sh
+++ b/scalardl-cleanup/ci/e2e/common.sh
@@ -5,7 +5,10 @@
 #   source ci/e2e/common.sh
 #
 # It holds the cluster facts both scripts must agree on -- namespaces, the Auditor's TLS SAN and
-# where its cert lives -- plus the kubectl helpers they both use.
+# where its cert lives -- plus the kubectl, Job and Cosmos helpers they use.
+#
+# The Job helpers assume the deployed Jobs run the cleanup tool, which prints its machine-readable
+# result as a single JSON line on stdout and everything else on stderr.
 
 # K8s namespaces. Exported because the manifests refer to them as ${LEDGER_NS} / ${AUDITOR_NS}.
 export LEDGER_NS="ledger-e2e"
@@ -24,19 +27,31 @@ require_vars() {
   done
 }
 
-# Dump everything useful about a namespace's workloads, then fail.
+# Dump everything useful about a namespace's workloads, then fail. Everything goes to stderr so that
+# the diagnostics still reach the log when this runs inside a command substitution -- where stdout is
+# the caller's return value, and where `exit` only ends the subshell (the caller then aborts on the
+# failed substitution because of `set -e`).
 diag_and_die() {
   local ns="$1" msg="$2"
-  echo "::error::${msg}"
-  echo "----- pods (${ns}) -----";            kubectl -n "$ns" get pods -o wide || true
-  echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
-  echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
-  echo "----- logs (${ns}) -----"
-  for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null || true); do
-    echo "### $p"
-    kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
-  done
+  {
+    echo "::error::${msg}"
+    echo "----- pods (${ns}) -----";            kubectl -n "$ns" get pods -o wide || true
+    echo "----- events (${ns}) -----";          kubectl -n "$ns" get events --sort-by=.lastTimestamp || true
+    echo "----- describe pods (${ns}) -----";   kubectl -n "$ns" describe pods || true
+    echo "----- logs (${ns}) -----"
+    for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null || true); do
+      echo "### $p"
+      kubectl -n "$ns" logs "$p" --all-containers --prefix --tail=200 || true
+    done
+  } >&2
   exit 1
+}
+
+# Whether a Job carries the given condition ("Complete" or "Failed") with status True.
+# Usage: job_has_condition <namespace> <job> <condition>
+job_has_condition() {
+  kubectl -n "$1" get "job/$2" \
+    -o jsonpath="{.status.conditions[?(@.type==\"$3\")].status}" 2>/dev/null | grep -q True
 }
 
 # Poll a Job for complete/failed (kubectl wait --for=complete hangs on failure),
@@ -44,10 +59,10 @@ diag_and_die() {
 wait_for_job() {
   local ns="$1" job="$2" timeout="${3:-300}" waited=0
   while true; do
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q True; then
+    if job_has_condition "$ns" "$job" Complete; then
       echo "job/$job complete"; return 0
     fi
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q True; then
+    if job_has_condition "$ns" "$job" Failed; then
       diag_and_die "$ns" "job/$job failed"
     fi
     if (( waited >= timeout )); then
@@ -55,4 +70,156 @@ wait_for_job() {
     fi
     sleep 5; waited=$((waited + 5))
   done
+}
+
+# Poll a Job until it either completes or fails, echoing which one happened. Unlike wait_for_job,
+# a failure is a legitimate outcome here: the negative tests assert on it, and an interrupted run
+# whose Job cannot retry ends up Failed by design.
+# Usage: wait_for_job_terminal <namespace> <job> [timeout]
+wait_for_job_terminal() {
+  local ns="$1" job="$2" timeout="${3:-300}" waited=0
+  while true; do
+    if job_has_condition "$ns" "$job" Complete; then printf 'Complete\n'; return 0; fi
+    if job_has_condition "$ns" "$job" Failed; then printf 'Failed\n'; return 0; fi
+    if (( waited >= timeout )); then
+      diag_and_die "$ns" "job/$job did not reach a terminal state within ${timeout}s"
+    fi
+    sleep 5; waited=$((waited + 5))
+  done
+}
+
+# Echo the name of the most recently created Pod of a Job in the given phase, or nothing. Callers
+# report the empty result themselves, so a kubectl failure must not abort them either (`|| true`).
+# Usage: job_pod <namespace> <job> <phase>
+job_pod() {
+  kubectl -n "$1" get pod -l "job-name=$2" --field-selector="status.phase=$3" \
+    --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+    | awk '{print $NF}' || true
+}
+
+# Echo the log of a Job's Pod in the given phase, or fail if there is no such Pod.
+# Usage: read_job_log <namespace> <job> <phase>
+read_job_log() {
+  local ns="$1" job="$2" phase="$3" pod
+  pod=$(job_pod "$ns" "$job" "$phase")
+  [ -n "$pod" ] || { echo "::error::no $phase Pod found for job/$job in $ns" >&2; return 1; }
+  kubectl -n "$ns" logs "$pod"
+}
+
+# Fail unless the log of a Job's Pod in the given phase contains the given text.
+# Usage: assert_job_log_contains <namespace> <job> <phase> <text>
+assert_job_log_contains() {
+  local ns="$1" job="$2" phase="$3" text="$4" log
+  log=$(read_job_log "$ns" "$job" "$phase")
+  if ! printf '%s\n' "$log" | grep -qF "$text"; then
+    echo "::error::job/$job did not log \"$text\""
+    printf '%s\n' "$log" | tail -n 50
+    return 1
+  fi
+  echo "job/$job logged \"$text\" as expected"
+}
+
+# Interrupt a running Job the moment it reports that it has started working, by force-deleting its
+# Pod -- the E2E stand-in for the crash (OOM kill, node eviction, operator ^C) that a resumable
+# command has to survive. The marker is a log line printed only after the command has persisted its
+# initial checkpoint state, so a resumed run is guaranteed to find a checkpoint to resume from.
+#
+# Echoes what happened: "interrupted" if a Pod was killed, or "finished" if the Job reached a
+# terminal state first (possible with the small E2E dataset, where the whole sweep can outrun the
+# poll below; the caller's re-run then still exercises the resume path).
+# Usage: interrupt_job <namespace> <job> <marker> [timeout]
+interrupt_job() {
+  local ns="$1" job="$2" marker="$3" timeout="${4:-300}" waited=0 pod
+  while (( waited < timeout )); do
+    if job_has_condition "$ns" "$job" Complete || job_has_condition "$ns" "$job" Failed; then
+      printf 'finished\n'; return 0
+    fi
+    pod=$(kubectl -n "$ns" get pod -l "job-name=$job" --field-selector=status.phase=Running \
+      -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | awk '{print $1}' || true)
+    if [ -n "$pod" ] && kubectl -n "$ns" logs "$pod" 2>/dev/null | grep -qF "$marker"; then
+      echo "==> interrupting job/$job: force-deleting pod/$pod after it logged \"$marker\"" >&2
+      kubectl -n "$ns" delete "pod/$pod" --grace-period=0 --force --wait=false >&2
+      printf 'interrupted\n'; return 0
+    fi
+    sleep 1; waited=$((waited + 1))
+  done
+  diag_and_die "$ns" "job/$job neither logged \"$marker\" nor finished within ${timeout}s"
+}
+
+# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
+# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
+# Usage: upsert_credentials_secret <namespace> <cosmos-key>
+upsert_credentials_secret() {
+  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
+    --from-literal=SCALAR_DB_PASSWORD="$2" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
+# re-run of this script would otherwise fail on apply. As in manage-cluster.sh, give envsubst an
+# explicit variable list so it substitutes ONLY these placeholders and never rewrites a literal
+# $VAR that later lands in a manifest. The tokens are unset until Step 3 and expand to empty, but
+# the finalize manifests never reference them.
+# Usage: apply_job <namespace> <job> <manifest>
+apply_job() {
+  kubectl -n "$1" delete "job/$2" --ignore-not-found
+  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
+}
+
+# Echo the tool's JSON output from the Pod of a completed Job in the given phase. The tool prints its
+# JSON on stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what
+# picks the JSON line out of the log4j lines around it.
+# Usage: read_job_json <namespace> <job> <phase>
+read_job_json() {
+  local ns="$1" job="$2" phase="$3" json
+  json=$(read_job_log "$ns" "$job" "$phase" \
+    | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
+  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
+  printf '%s\n' "$json"
+}
+
+# Echo the JSON output of a Job that succeeded / failed.
+# Usage: read_job_output_json <namespace> <job> | read_job_error_json <namespace> <job>
+read_job_output_json() { read_job_json "$1" "$2" Succeeded; }
+read_job_error_json() { read_job_json "$1" "$2" Failed; }
+
+# Fail unless the given error JSON reports the expected status code and carries the expected
+# structured error code (e.g. DL-TOOLS-1005) in its message.
+# Usage: assert_error_json <json> <expected-status-code> <expected-error-code>
+assert_error_json() {
+  local json="$1" expected_status="$2" expected_code="$3" status message
+  status=$(printf '%s' "$json" | jq -r '.status_code // empty')
+  message=$(printf '%s' "$json" | jq -r '.error_message // empty')
+  if [ "$status" != "$expected_status" ]; then
+    echo "::error::expected status_code $expected_status but got '$status' ($json)"; return 1
+  fi
+  case "$message" in
+    *"$expected_code"*) ;;
+    *) echo "::error::expected error code $expected_code in the message but got '$message'"; return 1 ;;
+  esac
+  echo "rejected as expected: $message"
+}
+
+# Count items in a container, authenticating with the given account endpoint and key.
+# Usage: count_cosmos_items <endpoint> <key> <database> <container>
+count_cosmos_items() {
+  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
+  output=$("$COSMOSDB_SHELL" <<EOF
+connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
+cd ${database}
+cd ${container}
+query "SELECT * FROM c" | jq '.items | length'
+exit
+EOF
+)
+  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
+  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
+  # can report a useful error.
+  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
+  if [ -z "$count" ]; then
+    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+  printf '%s\n' "$count"
 }

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -1,18 +1,42 @@
 #!/usr/bin/env bash
 #
-# Run the three ScalarDL Cleanup commands against the deployed E2E cluster the way an operator does:
+# Run the ScalarDL Cleanup commands against the deployed E2E cluster the way an operator does:
 #
 #   Step 1 (Ledger AD)  credentials Secret -> checkpoint PVC -> ConfigMap -> finalize-ledger Job
 #   Step 2 (Auditor AD) credentials Secret -> checkpoint PVC -> ConfigMap (+ TLS optional settings)
 #                       -> finalize-auditor Job
 #   Step 3 (Ledger AD)  cleanup-coordinator Job, with both completion tokens
 #
+# One phase per invocation, so .github/workflows/e2e.yaml can interleave the server upgrade and
+# fresh client traffic between them:
+#
+#   reject-old-auditor          finalize-auditor against the not-yet-upgraded Auditor must fail with
+#                               an error telling the operator to upgrade, because the privileged
+#                               RecoverAssetLock RPC does not exist there. Runs before the upgrade,
+#                               on a throwaway checkpoint volume of its own.
+#   finalize-ledger             Step 1. Interrupted midway and resumed by the Job's own retry, then
+#                               re-run once more to prove a re-run changes nothing.
+#   interrupt-finalize-auditor  Step 2, first attempt only: killed midway with retries disabled, so
+#                               that the workflow can run new client traffic before the command is
+#                               resumed.
+#   finalize-auditor            Step 2, resumed. Emits the Auditor token and must delete exactly the
+#                               request_proof records that predate its guarantee timestamp, leaving
+#                               every record the new traffic created in place.
+#   cleanup-coordinator         Step 3. Mixed-up tokens are rejected first, then the real run is
+#                               interrupted, resumed and re-run.
+#
+# Each phase hands what the next one needs (completion tokens, row counts) to a file under
+# RUNNER_TEMP.
+#
 # Expects in the environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
 #   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
-#   RUNNER_TEMP      scratch directory for the rendered ConfigMaps
+#   RUNNER_TEMP      scratch directory for the rendered manifests and the phase handover files
 #   RECORD_COUNT     number of records populated per category
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
+#
+# Usage:
+#   ./run-cleanup.sh <phase>
 
 set -euo pipefail
 
@@ -26,6 +50,24 @@ require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
 export CLEANUP_VERSION
 
 MANIFESTS="$HERE/../../manifests"
+
+# Job names, as defined in the manifests.
+LEDGER_JOB="scalardl-finalize-ledger"
+AUDITOR_JOB="scalardl-finalize-auditor"
+COORDINATOR_JOB="scalardl-cleanup-coordinator"
+
+# Names for the two negative tests, which get resources of their own so that a deliberate failure
+# never interferes with the real run's Job or checkpoint.
+OLD_SERVER_CHECK_JOB="scalardl-finalize-auditor-old-server-check"
+OLD_SERVER_CHECK_PVC="scalardl-cleanup-checkpoint-old-server-check"
+MIXED_TOKENS_JOB="scalardl-cleanup-coordinator-mixed-tokens"
+
+# Log line every command prints once it has persisted its initial checkpoint state, and the line a
+# run prints when it picks that checkpoint up again.
+LEDGER_START_MARKER="Starting a new run at"
+AUDITOR_START_MARKER="Starting a new run at"
+COORDINATOR_START_MARKER="Starting a new run."
+RESUME_MARKER="Found existing checkpoint data"
 
 # Working copy of the manifests, one directory per administrative domain as in the source tree.
 work="$RUNNER_TEMP/manifests"
@@ -50,38 +92,13 @@ ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
 auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
 auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
 
-# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
-# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
-# Usage: upsert_credentials_secret <namespace> <cosmos-key>
-upsert_credentials_secret() {
-  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
-    --from-literal=SCALAR_DB_PASSWORD="$2" \
-    --dry-run=client -o yaml | kubectl apply -f -
-}
-
-# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
-# re-run of this script would otherwise fail on apply. As in manage-cluster.sh, give envsubst an
-# explicit variable list so it substitutes ONLY these placeholders and never rewrites a literal
-# $VAR that later lands in a manifest. The tokens are unset until Step 3 and expand to empty, but
-# the finalize manifests never reference them.
-# Usage: apply_job <namespace> <job> <manifest>
-apply_job() {
-  kubectl -n "$1" delete "job/$2" --ignore-not-found
-  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
-}
-
-# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
-# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
-# JSON line out of the log4j lines around it.
-# Usage: read_job_output_json <namespace> <job>
-read_job_output_json() {
-  local ns="$1" job="$2" pod json
-  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
-    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
-  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
-  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
-  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
-  printf '%s\n' "$json"
+# Hand a value to a later phase, and read it back. A missing file means the phases ran out of order.
+# Usage: save_handover <name> <value> | load_handover <name>
+save_handover() { printf '%s\n' "$2" > "$RUNNER_TEMP/handover-$1"; }
+load_handover() {
+  local file="$RUNNER_TEMP/handover-$1"
+  [ -s "$file" ] || { echo "::error::handover file $file is missing; run the earlier phases first" >&2; return 1; }
+  cat "$file"
 }
 
 # Extract a non-empty completion token from a finalize command's JSON output, or fail.
@@ -93,110 +110,318 @@ extract_completion_token() {
   printf '%s\n' "$token"
 }
 
-# Count items in a container, authenticating with the given account endpoint and key.
-# Usage: count_cosmos_items <endpoint> <key> <database> <container>
-count_cosmos_items() {
-  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
-  output=$("$COSMOSDB_SHELL" <<EOF
-connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
-cd ${database}
-cd ${container}
-query "SELECT * FROM c" | jq '.items | length'
-exit
-EOF
-)
-  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
-  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
-  # can report a useful error.
-  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
-  if [ -z "$count" ]; then
-    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
-    printf '%s\n' "$output" >&2
-    return 1
-  fi
-  printf '%s\n' "$count"
+# Echo a Job manifest with the Job's retries disabled. A negative test reads the error output of the
+# very first attempt, and the manifests' backoffLimit would re-run the command three more times
+# before the Job reports Failed. It also keeps an interrupted Job down until it is applied again.
+# Usage: render_without_retry <manifest>
+render_without_retry() { sed 's/^\( *\)backoffLimit: [0-9]*$/\1backoffLimit: 0/' "$1"; }
+
+# Prepare the Ledger AD for its Jobs: credentials Secret, checkpoint volume, ConfigMap. Idempotent,
+# so every Ledger-side phase can call it without caring which ones ran before.
+prepare_ledger_ad() {
+  upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
+  # Apply the ConfigMap, substituting contact_points first.
+  sed "s|<cosmos-account-uri>|$ledger_uri|" \
+    "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
 }
 
-# --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
-echo "== Step 1: finalize-ledger =="
+# Prepare the Auditor AD for its Jobs: credentials Secret, checkpoint volume, ConfigMap, cert Secret.
+# Idempotent. An alternative PVC manifest can be passed for a run that must not share the checkpoint.
+# Usage: prepare_auditor_ad [pvc-manifest]
+prepare_auditor_ad() {
+  upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+  kubectl -n "$AUDITOR_NS" apply -f "${1:-$work/auditor-ad/pvc.yaml}"
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+  # Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
+  # serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
+  sed -E \
+    -e "s|<cosmos-account-uri>|$auditor_uri|" \
+    -e "s|<auditor-host>|auditor|" \
+    -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
+    -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
+    "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
+  kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
 
-# (b) Create the checkpoint volume.
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
+  # Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
+  # Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
+  kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
+    --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
 
-# (c) Apply the ConfigMap, substituting contact_points first.
-sed "s|<cosmos-account-uri>|$ledger_uri|" \
-  "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
+# Apply a Job, interrupt it midway, and let the Job's own retry resume it from the checkpoint. Fails
+# unless the attempt that finished the work resumed instead of starting over.
+# Usage: run_interrupted_and_resumed <namespace> <job> <manifest> <start-marker> [timeout]
+run_interrupted_and_resumed() {
+  local ns="$1" job="$2" manifest="$3" marker="$4" timeout="${5:-600}" outcome
+  apply_job "$ns" "$job" "$manifest"
+  outcome=$(interrupt_job "$ns" "$job" "$marker" "$timeout")
+  wait_for_job "$ns" "$job" "$timeout"
+  if [ "$outcome" = interrupted ]; then
+    assert_job_log_contains "$ns" "$job" Succeeded "$RESUME_MARKER"
+  else
+    echo "NOTE: job/$job finished before it could be interrupted; the re-run below still covers" \
+      "the resume path, and the assertions on the final state are the same either way."
+  fi
+}
 
-# (d) Run the Job.
-apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
-wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
-ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
-echo "finalize-ledger output: $ledger_out"
-token_l=$(extract_completion_token finalize-ledger "$ledger_out")
+# Re-run a Job that already did its work, against the same checkpoint volume: the command must find
+# the checkpoint, leave the data alone and report the same result. Echoes the re-run's JSON output.
+# Usage: rerun_job <namespace> <job> <manifest> [timeout]
+rerun_job() {
+  local ns="$1" job="$2" manifest="$3" timeout="${4:-600}"
+  apply_job "$ns" "$job" "$manifest" >&2
+  wait_for_job "$ns" "$job" "$timeout" >&2
+  assert_job_log_contains "$ns" "$job" Succeeded "$RESUME_MARKER" >&2
+  read_job_output_json "$ns" "$job"
+}
 
-# --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
-echo "== Step 2: finalize-auditor =="
+# --- Phase: finalize-auditor against a not-yet-upgraded Auditor ---------------------------------
+# The old server has no RecoverAssetLock RPC, so the command cannot finalize a single lock. It must
+# say so in a way that points at the fix (upgrade the Auditor) instead of surfacing the raw gRPC
+# "UNIMPLEMENTED: Method not found" failure.
+phase_reject_old_auditor() {
+  echo "== Negative: finalize-auditor against the pre-upgrade Auditor =="
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+  # Give this run a checkpoint volume and a Job name of its own: a checkpoint left behind here would
+  # pin the real Step 2 to a guarantee timestamp captured before the upgrade.
+  sed "s|scalardl-cleanup-checkpoint|$OLD_SERVER_CHECK_PVC|" \
+    "$MANIFESTS/auditor-ad/pvc.yaml" > "$work/auditor-ad/pvc-old-server-check.yaml"
+  prepare_auditor_ad "$work/auditor-ad/pvc-old-server-check.yaml"
 
-# (b) Create the checkpoint volume.
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
+  render_without_retry "$MANIFESTS/auditor-ad/finalize-auditor.yaml" \
+    | sed -e "s|scalardl-cleanup-checkpoint|$OLD_SERVER_CHECK_PVC|" \
+          -e "s|^\( *\)name: $AUDITOR_JOB\$|\1name: $OLD_SERVER_CHECK_JOB|" \
+    > "$work/auditor-ad/finalize-auditor-old-server-check.yaml"
 
-# (c) Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
-# serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
-sed -E \
-  -e "s|<cosmos-account-uri>|$auditor_uri|" \
-  -e "s|<auditor-host>|auditor|" \
-  -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
-  -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
-  "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
+  apply_job "$AUDITOR_NS" "$OLD_SERVER_CHECK_JOB" \
+    "$work/auditor-ad/finalize-auditor-old-server-check.yaml"
+  local result output message
+  result=$(wait_for_job_terminal "$AUDITOR_NS" "$OLD_SERVER_CHECK_JOB" 600)
+  [ "$result" = Failed ] || {
+    echo "::error::finalize-auditor was expected to fail against the pre-upgrade Auditor but ended as $result"
+    exit 1
+  }
 
-# Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
-# Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
-kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
-  --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
-  --dry-run=client -o yaml | kubectl apply -f -
+  output=$(read_job_error_json "$AUDITOR_NS" "$OLD_SERVER_CHECK_JOB")
+  # DL-TOOLS-1014 is RECOVER_ASSET_LOCK_UNSUPPORTED: a USER_ERROR, not an opaque internal failure.
+  assert_error_json "$output" USER_ERROR DL-TOOLS-1014
+  message=$(printf '%s' "$output" | jq -r '.error_message')
+  printf '%s' "$message" | grep -qi 'upgrade the auditor' || {
+    echo "::error::the error message does not tell the operator to upgrade the Auditor: $message"
+    exit 1
+  }
 
-# (d) Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
-# timeout.
-rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
-wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
-auditor_out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
-echo "finalize-auditor output: $auditor_out"
-token_a=$(extract_completion_token finalize-auditor "$auditor_out")
-rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-echo "request_proof rows: before=$rp_before after=$rp_after"
-[ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
+  # Drop the throwaway Job and volume so nothing of this run outlives the phase.
+  kubectl -n "$AUDITOR_NS" delete "job/$OLD_SERVER_CHECK_JOB" --ignore-not-found
+  # --wait=false: the PVC keeps its protection finalizer until the Job's Pod is fully gone, and
+  # nothing after this phase refers to this claim.
+  kubectl -n "$AUDITOR_NS" delete "pvc/$OLD_SERVER_CHECK_PVC" --ignore-not-found --wait=false
 
-# --- Step 3 (Ledger AD): cleanup-coordinator ---------------------------------------------------
-echo "== Step 3: cleanup-coordinator =="
+  echo "finalize-auditor rejected the pre-upgrade Auditor with an actionable error."
+}
 
-# The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
-export LEDGER_TOKEN="$token_l" AUDITOR_TOKEN="$token_a"
+# --- Phase: Step 1 (Ledger AD): finalize-ledger --------------------------------------------------
+phase_finalize_ledger() {
+  echo "== Step 1: finalize-ledger =="
+  prepare_ledger_ad
 
-cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
-wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
-coord_out=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
-echo "cleanup-coordinator output: $coord_out"
-[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
-  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
+  local manifest="$work/ledger-ad/finalize-ledger.yaml" output token rerun rerun_token
+  run_interrupted_and_resumed "$LEDGER_NS" "$LEDGER_JOB" "$manifest" "$LEDGER_START_MARKER" 600
+  output=$(read_job_output_json "$LEDGER_NS" "$LEDGER_JOB")
+  echo "finalize-ledger output: $output"
+  token=$(extract_completion_token finalize-ledger "$output")
 
-cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-# Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
-# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
-# writing coordinator.state rows after the boundary, which survive and are not counted here.
-echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
-[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
-  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
-[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
-  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
+  # The interrupted-then-resumed run has to land on the same completion token a single uninterrupted
+  # run would emit. The token is derived from the guarantee timestamp in the checkpoint, so a re-run
+  # against that checkpoint reproduces it; a run that had silently started over would not.
+  rerun=$(rerun_job "$LEDGER_NS" "$LEDGER_JOB" "$manifest" 600)
+  rerun_token=$(extract_completion_token finalize-ledger "$rerun")
+  [ "$rerun_token" = "$token" ] || {
+    echo "::error::finalize-ledger emitted a different token on the re-run: $token vs $rerun_token"
+    exit 1
+  }
 
-echo "All three cleanup commands succeeded."
+  save_handover ledger-token "$token"
+  echo "finalize-ledger completed; its token survived the interruption unchanged."
+}
+
+# --- Phase: Step 2 (Auditor AD), first attempt: interrupt finalize-auditor -----------------------
+# Stops the command after it has captured and persisted its guarantee timestamp but before it has
+# finished, so the workflow can commit new transactions that are strictly newer than that timestamp.
+phase_interrupt_finalize_auditor() {
+  echo "== Step 2 (first attempt): finalize-auditor, interrupted midway =="
+  prepare_auditor_ad
+
+  # Retries disabled so the Job stays down after the kill instead of racing the new traffic.
+  render_without_retry "$MANIFESTS/auditor-ad/finalize-auditor.yaml" \
+    > "$work/auditor-ad/finalize-auditor-no-retry.yaml"
+
+  local outcome result failed_pod remaining
+  apply_job "$AUDITOR_NS" "$AUDITOR_JOB" "$work/auditor-ad/finalize-auditor-no-retry.yaml"
+  outcome=$(interrupt_job "$AUDITOR_NS" "$AUDITOR_JOB" "$AUDITOR_START_MARKER" 900)
+  result=$(wait_for_job_terminal "$AUDITOR_NS" "$AUDITOR_JOB" 900)
+  echo "the first attempt ended as $result ($outcome)"
+
+  if [ "$result" = Failed ]; then
+    # A force-deleted Pod leaves no Failed Pod behind, so one here would mean the command itself
+    # errored out -- which is not the interruption this phase is arranging.
+    failed_pod=$(job_pod "$AUDITOR_NS" "$AUDITOR_JOB" Failed)
+    [ -z "$failed_pod" ] || diag_and_die "$AUDITOR_NS" \
+      "the interrupted finalize-auditor attempt failed with a tool error, not the interruption"
+  fi
+
+  # Whatever request_proof rows are still here predate the guarantee timestamp this attempt
+  # persisted, so the resumed run must delete exactly these and keep everything added afterwards.
+  remaining=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+  save_handover request-proof-count-before-traffic "$remaining"
+  echo "request_proof rows left by the interrupted attempt: $remaining"
+}
+
+# --- Phase: Step 2 (Auditor AD), resumed: finalize-auditor ---------------------------------------
+phase_finalize_auditor() {
+  echo "== Step 2 (resumed): finalize-auditor =="
+  prepare_auditor_ad
+
+  local manifest="$work/auditor-ad/finalize-auditor.yaml"
+  local before pre_traffic new_rows output token after rerun rerun_token rerun_after
+  before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+  pre_traffic=$(load_handover request-proof-count-before-traffic)
+  new_rows=$((before - pre_traffic))
+  echo "request_proof rows: $before now, $pre_traffic before the new traffic (new: $new_rows)"
+  [ "$new_rows" -gt 0 ] || {
+    echo "::error::the new traffic added no request_proof rows, so this phase would prove nothing"
+    exit 1
+  }
+
+  apply_job "$AUDITOR_NS" "$AUDITOR_JOB" "$manifest"
+  wait_for_job "$AUDITOR_NS" "$AUDITOR_JOB" 900
+  # The resumed run must pick the interrupted attempt's checkpoint up rather than capture a fresh
+  # guarantee timestamp, which is what keeps the new traffic outside the deletion window.
+  assert_job_log_contains "$AUDITOR_NS" "$AUDITOR_JOB" Succeeded "$RESUME_MARKER"
+  output=$(read_job_output_json "$AUDITOR_NS" "$AUDITOR_JOB")
+  echo "finalize-auditor output: $output"
+  token=$(extract_completion_token finalize-auditor "$output")
+
+  # Every record registered before the guarantee timestamp is gone, and every record the new traffic
+  # created after it is still there. The Auditor's own transaction state purge is disabled (its
+  # default), so the tool is the only thing that can delete a request_proof record here.
+  after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+  echo "request_proof rows after finalize-auditor: $after (expected $new_rows)"
+  [ "$after" -eq "$new_rows" ] || {
+    echo "::error::finalize-auditor left $after request_proof rows (expected the $new_rows rows of new traffic)"
+    exit 1
+  }
+
+  # Re-running the command must be a no-op: same token, and the new traffic's records untouched.
+  rerun=$(rerun_job "$AUDITOR_NS" "$AUDITOR_JOB" "$manifest" 900)
+  rerun_token=$(extract_completion_token finalize-auditor "$rerun")
+  [ "$rerun_token" = "$token" ] || {
+    echo "::error::finalize-auditor emitted a different token on the re-run: $token vs $rerun_token"
+    exit 1
+  }
+  rerun_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+  [ "$rerun_after" -eq "$after" ] || {
+    echo "::error::the finalize-auditor re-run changed the request_proof rows: $after -> $rerun_after"
+    exit 1
+  }
+
+  save_handover auditor-token "$token"
+  echo "finalize-auditor completed; the records created after its guarantee timestamp survived."
+}
+
+# --- Phase: Step 3 (Ledger AD): cleanup-coordinator ----------------------------------------------
+phase_cleanup_coordinator() {
+  echo "== Step 3: cleanup-coordinator =="
+  prepare_ledger_ad
+
+  local token_l token_a
+  token_l=$(load_handover ledger-token)
+  token_a=$(load_handover auditor-token)
+
+  reject_mixed_tokens "$token_l" "$token_a"
+
+  # The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
+  export LEDGER_TOKEN="$token_l" AUDITOR_TOKEN="$token_a"
+
+  local manifest="$work/ledger-ad/cleanup-coordinator.yaml"
+  local before after deleted expected_before expected_after rerun rerun_after
+  before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+  run_interrupted_and_resumed "$LEDGER_NS" "$COORDINATOR_JOB" "$manifest" \
+    "$COORDINATOR_START_MARKER" 600
+  local output
+  output=$(read_job_output_json "$LEDGER_NS" "$COORDINATOR_JOB")
+  echo "cleanup-coordinator output: $output"
+  [ "$(printf '%s' "$output" | jq -r '.status_code')" = "OK" ] \
+    || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
+
+  after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+  deleted=$((before - after))
+  # Only the RECORD_COUNT committed put transactions settled before the deletable-before boundary,
+  # so exactly those are removed. What must survive is
+  #   2 * RECORD_COUNT  the nonce aborts finalize-auditor wrote while recovering the stranded write
+  #                     and read locks, all after the boundary, and
+  #   1 * RECORD_COUNT  the transactions of the new traffic the workflow ran after both guarantee
+  #                     timestamps were captured -- the records this test must prove are left alone.
+  expected_before=$((4 * RECORD_COUNT))
+  expected_after=$((3 * RECORD_COUNT))
+  echo "coordinator.state rows: before=$before after=$after deleted=$deleted"
+  [ "$before" -eq "$expected_before" ] \
+    || { echo "::error::coordinator.state had $before rows before cleanup (expected $expected_before)"; exit 1; }
+  [ "$deleted" -eq "$RECORD_COUNT" ] \
+    || { echo "::error::cleanup-coordinator deleted $deleted coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
+  [ "$after" -eq "$expected_after" ] \
+    || { echo "::error::coordinator.state has $after rows after cleanup (expected $expected_after)"; exit 1; }
+
+  # Re-running the command must delete nothing more.
+  rerun=$(rerun_job "$LEDGER_NS" "$COORDINATOR_JOB" "$manifest" 600)
+  [ "$(printf '%s' "$rerun" | jq -r '.status_code')" = "OK" ] \
+    || { echo "::error::the cleanup-coordinator re-run did not report OK"; exit 1; }
+  rerun_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+  [ "$rerun_after" -eq "$after" ] || {
+    echo "::error::the cleanup-coordinator re-run changed the coordinator.state rows: $after -> $rerun_after"
+    exit 1
+  }
+
+  echo "cleanup-coordinator deleted only the settled records; the new traffic's records survived."
+}
+
+# Swapping the two tokens must be refused by the server-type validation before anything is deleted.
+# This runs while no coordinator-cleanup checkpoint exists yet: once there is one, the tokens are
+# ignored on purpose so that a resumed run keeps its original deletion boundary.
+# Usage: reject_mixed_tokens <ledger-token> <auditor-token>
+reject_mixed_tokens() {
+  echo "== Negative: cleanup-coordinator with the two tokens swapped =="
+  local manifest="$work/ledger-ad/cleanup-coordinator-mixed-tokens.yaml" result output
+  render_without_retry "$MANIFESTS/ledger-ad/cleanup-coordinator.yaml" \
+    | sed "s|^\( *\)name: $COORDINATOR_JOB\$|\1name: $MIXED_TOKENS_JOB|" > "$manifest"
+
+  # The Auditor token goes to --ledger-token and vice versa. envsubst only sees exported variables,
+  # and the caller exports the correct pairing right after this function returns.
+  export LEDGER_TOKEN="$2" AUDITOR_TOKEN="$1"
+  apply_job "$LEDGER_NS" "$MIXED_TOKENS_JOB" "$manifest"
+  result=$(wait_for_job_terminal "$LEDGER_NS" "$MIXED_TOKENS_JOB" 600)
+  [ "$result" = Failed ] || {
+    echo "::error::cleanup-coordinator accepted the swapped tokens (job ended as $result)"
+    exit 1
+  }
+  output=$(read_job_error_json "$LEDGER_NS" "$MIXED_TOKENS_JOB")
+  # DL-TOOLS-1005 is LEDGER_TOKEN_WRONG_SERVER_TYPE: the Ledger token is validated first.
+  assert_error_json "$output" USER_ERROR DL-TOOLS-1005
+
+  kubectl -n "$LEDGER_NS" delete "job/$MIXED_TOKENS_JOB" --ignore-not-found
+}
+
+case "${1:-}" in
+  reject-old-auditor)         phase_reject_old_auditor ;;
+  finalize-ledger)            phase_finalize_ledger ;;
+  interrupt-finalize-auditor) phase_interrupt_finalize_auditor ;;
+  finalize-auditor)           phase_finalize_auditor ;;
+  cleanup-coordinator)        phase_cleanup_coordinator ;;
+  *)
+    echo "usage: run-cleanup.sh [reject-old-auditor|finalize-ledger|interrupt-finalize-auditor|finalize-auditor|cleanup-coordinator]" >&2
+    exit 1
+    ;;
+esac

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
@@ -91,6 +91,18 @@ public enum ScalarDlCleanupError implements ScalarDlToolsError {
       "",
       "Verify that the configuration points to the database the Ledger uses and that the ScalarDL"
           + " schema has been loaded."),
+  // The solution below never reaches the operator: buildMessage() emits only the code and the
+  // message. The message therefore carries the "upgrade the Auditor" instruction itself, since the
+  // raw gRPC UNIMPLEMENTED failure it replaces gives no hint about what to do.
+  RECOVER_ASSET_LOCK_UNSUPPORTED(
+      Category.USER_ERROR,
+      "014",
+      "The Auditor does not provide the asset lock recovery API (the RecoverAssetLock RPC) that"
+          + " this command requires; upgrade the Auditor to a version that provides it and re-run"
+          + " this command.",
+      "",
+      "Upgrade the ScalarDL Auditor to a version that provides the asset lock recovery API"
+          + " (the RecoverAssetLock RPC) before running this command."),
 
   //
   // Errors for the internal error category

--- a/scalardl-cleanup/manifests/README.md
+++ b/scalardl-cleanup/manifests/README.md
@@ -55,6 +55,9 @@ their own domain's directory:
 - On the **Ledger** side, Coordinator group commit is disabled
   (`scalar.db.consensus_commit.coordinator.group_commit.enabled=false`, the default) — the tool does
   not support it and rejects it at runtime.
+- On the **Auditor** side, the server provides the privileged asset lock recovery API (the
+  `RecoverAssetLock` RPC) that `finalize-auditor` calls. Upgrade the Auditor first if it does not —
+  the command rejects an older server at runtime and tells you so.
 - The cluster's default `StorageClass` provides **`ReadWriteOnce`** volumes and honours `fsGroup`, so the non-root
   container can write the checkpoint.
 - Each Job requests **2 vCPU and 4 GiB of memory** (`requests` equal `limits`), so the target


### PR DESCRIPTION
## Description

This PR extends the E2E test to cover the four scenarios raised in the review on #55, which were left for a follow-up PR:

- resuming an interrupted command
- protecting traffic that arrives after the completion tokens are issued
- running against a pre-upgrade Auditor
- passing mixed-up tokens

The pre-upgrade scenario also required a product change, since the tool surfaced the missing `RecoverAssetLock` RPC as a raw gRPC error instead of telling the operator to upgrade.

## Related issues and/or PRs

- #55 

## Changes made

- Change `run-cleanup.sh` from running every cleanup command in one go to running the single command given as its argument, so the workflow can interleave the server upgrade and client traffic between them.
- Verify that interrupting a command midway and resuming it from the same checkpoint reaches the same result as an uninterrupted run, and that re-running a finished command changes nothing.
- Verify that the records created by traffic committed after both completion tokens are issued are left untouched.
- Verify that the commands reject a pre-upgrade Auditor and mixed-up completion tokens.
- Report a missing asset lock recovery API as a user error that tells the operator to upgrade the Auditor, instead of a raw gRPC failure.
- Move the shared Job and Cosmos helpers into `common.sh`, and document the Auditor-side prerequisite in `manifests/README.md`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A