### PR TITLE
Extract the E2E cleanup Job helpers into a shared library

### DIFF
--- a/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
+++ b/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Helpers for running the ScalarDL Cleanup commands as Kubernetes Jobs against the E2E cluster.
+# Source it:
+#
+#   source ci/e2e/cleanup-jobs.sh
+#
+# Expects in the environment:
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RUNNER_TEMP      scratch directory for the rendered manifests
+# and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed. It sets no shell
+# options of its own; the caller is expected to run under `set -euo pipefail`, which some of these
+# helpers rely on to surface a failure.
+#
+# The setup functions communicate through globals rather than arguments. Call them in this order,
+# and read what they set:
+#   init_manifests_workdir              -> work
+#   load_ad_credentials                 -> ledger_uri / ledger_key / auditor_uri / auditor_key
+#                                          (and ledger_props / auditor_props, their source files)
+#   setup_ledger_ad / setup_auditor_ad  take no arguments; both of the above must be set by then
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$E2E_DIR/common.sh"
+
+MANIFESTS="$E2E_DIR/../../manifests"
+
+# Working copy of the manifests, one directory per administrative domain as in the source tree.
+init_manifests_workdir() {
+  work="$RUNNER_TEMP/manifests"
+  rm -rf "$work"
+  mkdir -p "$work"
+  cp -R "$MANIFESTS/ledger-ad" "$MANIFESTS/auditor-ad" "$work/"
+}
+
+# Read a single property value from a properties file.
+# Usage: read_prop_value <file> <key>
+read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
+
+# Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
+# from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
+# and keeps these scripts free of secrets of their own.
+load_ad_credentials() {
+  ledger_props="$RUNNER_TEMP/ledger.properties"
+  auditor_props="$RUNNER_TEMP/auditor.properties"
+
+  kubectl -n "$LEDGER_NS"  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
+  kubectl -n "$AUDITOR_NS" get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
+  ledger_uri=$(read_prop_value "$ledger_props" scalar.db.contact_points)
+  ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
+  auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
+  auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
+}
+
+# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
+# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
+# Usage: upsert_credentials_secret <namespace> <cosmos-key>
+upsert_credentials_secret() {
+  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
+    --from-literal=SCALAR_DB_PASSWORD="$2" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Prepare the Ledger AD for its Jobs.
+setup_ledger_ad() {
+  # Create the credentials Secret.
+  upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+
+  # Create the checkpoint volume.
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
+
+  # Apply the ConfigMap, substituting contact_points first.
+  sed "s|<cosmos-account-uri>|$ledger_uri|" \
+    "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
+}
+
+# Prepare the Auditor AD for its Jobs.
+setup_auditor_ad() {
+  # Create the credentials Secret.
+  upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+
+  # Create the checkpoint volume.
+  kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
+
+  # Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
+  # serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
+  sed -E \
+    -e "s|<cosmos-account-uri>|$auditor_uri|" \
+    -e "s|<auditor-host>|auditor|" \
+    -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
+    -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
+    "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
+  kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
+
+  # Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
+  # Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
+  kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
+    --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
+# re-run would otherwise fail on apply. As in manage-cluster.sh, give envsubst an explicit variable
+# list so it substitutes ONLY these placeholders and never rewrites a literal $VAR that later lands
+# in a manifest. CLEANUP_VERSION must be exported, or the image tag renders empty; LEDGER_TOKEN and
+# AUDITOR_TOKEN expand to empty when unset, which is fine for a manifest that does not use them.
+# Usage: apply_job <namespace> <job> <manifest>
+apply_job() {
+  kubectl -n "$1" delete "job/$2" --ignore-not-found
+  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
+}
+
+# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
+# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
+# JSON line out of the log4j lines around it.
+# Usage: read_job_output_json <namespace> <job>
+read_job_output_json() {
+  local ns="$1" job="$2" pod json
+  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
+    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
+  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
+  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
+  printf '%s\n' "$json"
+}
+
+# Extract a non-empty completion token from a finalize command's JSON output, or fail.
+# Usage: extract_completion_token <command-name> <json>
+extract_completion_token() {
+  local name="$1" json="$2" token
+  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
+  [ -n "$token" ] || { echo "::error::$name emitted no completion token" >&2; return 1; }
+  printf '%s\n' "$token"
+}
+
+# Count items in a container, authenticating with the given account endpoint and key.
+# Usage: count_cosmos_items <endpoint> <key> <database> <container>
+count_cosmos_items() {
+  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
+  output=$("$COSMOSDB_SHELL" <<EOF
+connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
+cd ${database}
+cd ${container}
+query "SELECT * FROM c" | jq '.items | length'
+exit
+EOF
+)
+  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
+  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
+  # can report a useful error.
+  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
+  if [ -z "$count" ]; then
+    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+  printf '%s\n' "$count"
+}

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -17,121 +17,23 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/common.sh"
+source "$HERE/cleanup-jobs.sh"
 
 require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
 
 # The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
-# passed to kubectl instead. LEDGER_NS / AUDITOR_NS / AUDITOR_TLS_SAN come from common.sh exported.
+# passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
 export CLEANUP_VERSION
 
-MANIFESTS="$HERE/../../manifests"
-
-# Working copy of the manifests, one directory per administrative domain as in the source tree.
-work="$RUNNER_TEMP/manifests"
-rm -rf "$work"
-mkdir -p "$work"
-cp -R "$MANIFESTS/ledger-ad" "$MANIFESTS/auditor-ad" "$work/"
-
-ledger_props="$RUNNER_TEMP/ledger.properties"
-auditor_props="$RUNNER_TEMP/auditor.properties"
-
-# Read a single property value from a properties file.
-# Usage: read_prop_value <file> <key>
-read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
-
-# Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
-# from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
-# and keeps this script free of secrets of its own.
-kubectl -n "$LEDGER_NS"  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
-kubectl -n "$AUDITOR_NS" get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
-ledger_uri=$(read_prop_value "$ledger_props" scalar.db.contact_points)
-ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
-auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
-auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
-
-# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
-# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
-# Usage: upsert_credentials_secret <namespace> <cosmos-key>
-upsert_credentials_secret() {
-  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
-    --from-literal=SCALAR_DB_PASSWORD="$2" \
-    --dry-run=client -o yaml | kubectl apply -f -
-}
-
-# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
-# re-run of this script would otherwise fail on apply. As in manage-cluster.sh, give envsubst an
-# explicit variable list so it substitutes ONLY these placeholders and never rewrites a literal
-# $VAR that later lands in a manifest. The tokens are unset until Step 3 and expand to empty, but
-# the finalize manifests never reference them.
-# Usage: apply_job <namespace> <job> <manifest>
-apply_job() {
-  kubectl -n "$1" delete "job/$2" --ignore-not-found
-  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
-}
-
-# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
-# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
-# JSON line out of the log4j lines around it.
-# Usage: read_job_output_json <namespace> <job>
-read_job_output_json() {
-  local ns="$1" job="$2" pod json
-  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
-    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
-  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
-  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
-  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
-  printf '%s\n' "$json"
-}
-
-# Extract a non-empty completion token from a finalize command's JSON output, or fail.
-# Usage: extract_completion_token <command-name> <json>
-extract_completion_token() {
-  local name="$1" json="$2" token
-  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
-  [ -n "$token" ] || { echo "::error::$name emitted no completion token" >&2; return 1; }
-  printf '%s\n' "$token"
-}
-
-# Count items in a container, authenticating with the given account endpoint and key.
-# Usage: count_cosmos_items <endpoint> <key> <database> <container>
-count_cosmos_items() {
-  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
-  output=$("$COSMOSDB_SHELL" <<EOF
-connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
-cd ${database}
-cd ${container}
-query "SELECT * FROM c" | jq '.items | length'
-exit
-EOF
-)
-  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
-  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
-  # can report a useful error.
-  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
-  if [ -z "$count" ]; then
-    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
-    printf '%s\n' "$output" >&2
-    return 1
-  fi
-  printf '%s\n' "$count"
-}
+init_manifests_workdir
+load_ad_credentials
 
 # --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
 echo "== Step 1: finalize-ledger =="
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+setup_ledger_ad
 
-# (b) Create the checkpoint volume.
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
-
-# (c) Apply the ConfigMap, substituting contact_points first.
-sed "s|<cosmos-account-uri>|$ledger_uri|" \
-  "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
-
-# (d) Run the Job.
+# Run the Job.
 apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
 wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
 ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
@@ -141,29 +43,9 @@ token_l=$(extract_completion_token finalize-ledger "$ledger_out")
 # --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
 echo "== Step 2: finalize-auditor =="
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+setup_auditor_ad
 
-# (b) Create the checkpoint volume.
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
-
-# (c) Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
-# serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
-sed -E \
-  -e "s|<cosmos-account-uri>|$auditor_uri|" \
-  -e "s|<auditor-host>|auditor|" \
-  -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
-  -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
-  "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
-
-# Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
-# Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
-kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
-  --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-# (d) Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
+# Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
 # timeout.
 rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
 apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"


### PR DESCRIPTION
## Description

This PR is the first in a series that extends the ScalarDL Cleanup E2E test with the scenarios @jnmt raised in the review of #55. This change is a pure refactoring: it extracts common helpers from run-cleanup.sh so later scenarios can share them. Most of the diff is just a move.

## Related issues and/or PRs

- #55 

## Changes made

- Add `ci/e2e/cleanup-jobs.sh` with the per-AD setup and Job helpers extracted from `run-cleanup.sh`.
- Reduce `run-cleanup.sh` to the three-step driver that calls them.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A