### PR TITLE
Extract E2E data population into script

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,15 +7,7 @@ name: E2E
 #      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
 #   2. Upgrade both servers in place to the new version (which exposes the privileged
 #      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the three operator-facing cleanup subcommands against the upgraded cluster, deployed the
-#      way an operator deploys them: as Kubernetes Jobs from scalardl-cleanup/manifests, in the
-#      documented apply order (so the deployment procedure is under test too).
-#        finalize-ledger      -> emits the Ledger completion token
-#        finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and
-#                                cleans up request_proof; emits the Auditor completion token
-#        cleanup-coordinator  -> deletes the settled coordinator.state records
-#   4. Assert, at the ScalarDL application layer, that every existing asset is writable, readable,
-#      and passes validate-ledger.
+#   3. Run the scenario script in ci/e2e/scenarios.
 #
 # CI-only. Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
@@ -78,8 +70,7 @@ jobs:
         run: ./gradlew :cli:docker -PdockerVersion="$CLEANUP_VERSION"
 
       - name: Install Azure Cosmos DB Shell
-        # Used by run-cleanup.sh to count rows directly in Cosmos for the post-cleanup reclamation
-        # checks.
+        # Used by the scenarios to count rows directly in Cosmos for their reclamation checks.
         run: |
           set -euo pipefail
           v=1.1.4
@@ -137,35 +128,8 @@ jobs:
           SCALARDL_VERSION: ${{ env.SCALARDL_NEW_VERSION }}
         run: ./ci/e2e/manage-cluster.sh upgrade
 
-      - name: Run the cleanup commands as Kubernetes Jobs
-        run: ./ci/e2e/run-cleanup.sh
-
-      - name: Verify post-cleanup consistency
-        run: |
-          set -euo pipefail
-          source ci/e2e/port-forward.sh
-          pf_reset
-          pf_start ledger-e2e  svc/ledger  50051:50051 50052:50052
-          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
-          pf_wait 50051 50052 40051 40052
-          props="ci/e2e/client.properties"
-          populated="$RUNNER_TEMP/populated-assets.json"
-
-          # After cleanup, every asset must be fully usable again: writable, readable, and passing
-          # ledger validation.
-          while IFS= read -r id; do
-            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
-            if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
-              echo "::error::put-object on $id failed after cleanup"; exit 1
-            fi
-            if ! "$CLIENT" get-object --properties "$props" --object-id "$id"; then
-              echo "::error::get-object on $id failed after cleanup"; exit 1
-            fi
-            if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
-              echo "::error::validate-ledger on $id failed after cleanup"; exit 1
-            fi
-          done < <(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated")
-          echo "Post-cleanup consistency verified."
+      - name: Run scenario - happy path
+        run: ./ci/e2e/scenarios/happy-path.sh
 
       - name: Upload populated-assets
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -124,63 +124,13 @@ jobs:
         run: ./ci/e2e/manage-cluster.sh deploy
 
       - name: Populate committed data
-        run: |
-          set -euo pipefail
-          source ci/e2e/port-forward.sh
-          pf_reset
-          pf_start ledger-e2e  svc/ledger  50051:50051 50052:50052
-          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
-          pf_wait 50051 50052 40051 40052
-          props="ci/e2e/client.properties"
-          # Register the client identity + the generic object contracts on both servers.
-          "$CLIENT" bootstrap --properties "$props"
-          # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)
-          # produces asset / request_proof / coordinator.state / released asset_lock records.
-          for i in $(seq 0 $((RECORD_COUNT - 1))); do
-            id="e2e-asset-$i"
-            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
-            "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"
-          done
+        run: ./ci/e2e/populate.sh commit-objects
 
       - name: Generate stranded locks (Ledger down)
-        run: |
-          set -euo pipefail
-          source ci/e2e/port-forward.sh
-          pf_reset
-          ./ci/e2e/manage-cluster.sh stop-ledger
-          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
-          pf_wait 40051 40052
-          props="ci/e2e/client.properties"
-          # Every op MUST fail (Ledger down): the Auditor is left holding the lock. Fail the job if
-          # any unexpectedly succeeds. put-object leaves a WRITE lock on a fresh id; get-object leaves
-          # a READ lock on an already-committed id.
-          for i in $(seq 0 $((RECORD_COUNT - 1))); do
-            id="e2e-stranded-$i"
-            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
-            if "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
-              echo "::error::stranded put-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
-            fi
-          done
-          for i in $(seq 0 $((RECORD_COUNT - 1))); do
-            id="e2e-asset-$i"
-            if "$CLIENT" get-object --properties "$props" --object-id "$id"; then
-              echo "::error::stranded get-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
-            fi
-          done
-          echo "Waiting 16s for the held locks to pass the 15s valid period ..."
-          sleep 16
+        run: ./ci/e2e/populate.sh strand-locks
 
-      # Record what was populated. The verify step reads this back (single source of truth for the
-      # asset ids), and it is uploaded as an artifact for inspection. strandedReadAssetIds are the
-      # committed ids that also received a stranded READ lock (== committedAssetIds here).
       - name: Write populated-assets metadata
-        run: |
-          jq -n --argjson n "$RECORD_COUNT" '{
-            entityId: "e2e-client",
-            committedAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
-            strandedAssetIds: [range(0; $n) | "e2e-stranded-\(.)"],
-            strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"]
-          }' > "$RUNNER_TEMP/populated-assets.json"
+        run: ./ci/e2e/populate.sh write-metadata
 
       - name: Upgrade ScalarDL to the new version
         env:

--- a/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
+++ b/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Helpers for running the ScalarDL Cleanup commands as Kubernetes Jobs against the E2E cluster.
+# Source it:
+#
+#   source ci/e2e/cleanup-jobs.sh
+#
+# Expects in the environment:
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RUNNER_TEMP      scratch directory for the rendered manifests
+# and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed. It sets no shell
+# options of its own; the caller is expected to run under `set -euo pipefail`, which some of these
+# helpers rely on to surface a failure.
+#
+# The setup functions communicate through globals rather than arguments. Call them in this order,
+# and read what they set:
+#   init_manifests_workdir              -> work
+#   load_ad_credentials                 -> ledger_uri / ledger_key / auditor_uri / auditor_key
+#                                          (and ledger_props / auditor_props, their source files)
+#   setup_ledger_ad / setup_auditor_ad  take no arguments; both of the above must be set by then
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$E2E_DIR/common.sh"
+
+MANIFESTS="$E2E_DIR/../../manifests"
+
+# Working copy of the manifests, one directory per administrative domain as in the source tree.
+init_manifests_workdir() {
+  work="$RUNNER_TEMP/manifests"
+  rm -rf "$work"
+  mkdir -p "$work"
+  cp -R "$MANIFESTS/ledger-ad" "$MANIFESTS/auditor-ad" "$work/"
+}
+
+# Read a single property value from a properties file.
+# Usage: read_prop_value <file> <key>
+read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
+
+# Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
+# from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
+# and keeps these scripts free of secrets of their own.
+load_ad_credentials() {
+  ledger_props="$RUNNER_TEMP/ledger.properties"
+  auditor_props="$RUNNER_TEMP/auditor.properties"
+
+  kubectl -n "$LEDGER_NS"  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
+  kubectl -n "$AUDITOR_NS" get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
+  ledger_uri=$(read_prop_value "$ledger_props" scalar.db.contact_points)
+  ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
+  auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
+  auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
+}
+
+# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
+# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
+# Usage: upsert_credentials_secret <namespace> <cosmos-key>
+upsert_credentials_secret() {
+  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
+    --from-literal=SCALAR_DB_PASSWORD="$2" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Prepare the Ledger AD for its Jobs.
+setup_ledger_ad() {
+  # Create the credentials Secret.
+  upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+
+  # Create the checkpoint volume.
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
+
+  # Apply the ConfigMap, substituting contact_points first.
+  sed "s|<cosmos-account-uri>|$ledger_uri|" \
+    "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
+  kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
+}
+
+# Prepare the Auditor AD for its Jobs.
+setup_auditor_ad() {
+  # Create the credentials Secret.
+  upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+
+  # Create the checkpoint volume.
+  kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
+
+  # Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
+  # serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
+  sed -E \
+    -e "s|<cosmos-account-uri>|$auditor_uri|" \
+    -e "s|<auditor-host>|auditor|" \
+    -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
+    -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
+    "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
+  kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
+
+  # Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
+  # Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
+  kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
+    --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
+# re-run would otherwise fail on apply. As in manage-cluster.sh, give envsubst an explicit variable
+# list so it substitutes ONLY these placeholders and never rewrites a literal $VAR that later lands
+# in a manifest. CLEANUP_VERSION must be exported, or the image tag renders empty; LEDGER_TOKEN and
+# AUDITOR_TOKEN expand to empty when unset, which is fine for a manifest that does not use them.
+# Usage: apply_job <namespace> <job> <manifest>
+apply_job() {
+  kubectl -n "$1" delete "job/$2" --ignore-not-found
+  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
+}
+
+# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
+# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
+# JSON line out of the log4j lines around it.
+# Usage: read_job_output_json <namespace> <job>
+read_job_output_json() {
+  local ns="$1" job="$2" pod json
+  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
+    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
+  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
+  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
+  printf '%s\n' "$json"
+}
+
+# Extract a non-empty completion token from a finalize command's JSON output, or fail.
+# Usage: extract_completion_token <command-name> <json>
+extract_completion_token() {
+  local name="$1" json="$2" token
+  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
+  [ -n "$token" ] || { echo "::error::$name emitted no completion token" >&2; return 1; }
+  printf '%s\n' "$token"
+}
+
+# Count items in a container, authenticating with the given account endpoint and key.
+# Usage: count_cosmos_items <endpoint> <key> <database> <container>
+count_cosmos_items() {
+  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
+  output=$("$COSMOSDB_SHELL" <<EOF
+connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
+cd ${database}
+cd ${container}
+query "SELECT * FROM c" | jq '.items | length'
+exit
+EOF
+)
+  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
+  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
+  # can report a useful error.
+  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
+  if [ -z "$count" ]; then
+    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+  printf '%s\n' "$count"
+}

--- a/scalardl-cleanup/ci/e2e/manage-cluster.sh
+++ b/scalardl-cleanup/ci/e2e/manage-cluster.sh
@@ -36,7 +36,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Namespaces, the Auditor TLS SAN, CERTS_DIR, and the kubectl helpers (require_vars,
-# wait_for_job, diag_and_die) live here so run-cleanup.sh sees exactly the same values.
+# wait_for_job, diag_and_die) live here so every script in ci/e2e sees the same values.
 source "$HERE/common.sh"
 
 SCALARDL_VERSION_EXPLICIT="${SCALARDL_VERSION:+yes}"   # "yes" if set and non-empty, else ""

--- a/scalardl-cleanup/ci/e2e/populate.sh
+++ b/scalardl-cleanup/ci/e2e/populate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Populate the E2E cluster with the garbage the cleanup commands are meant to reclaim.
+#
+# Modes, in the order .github/workflows/e2e.yaml runs them:
+#   commit-objects  register the client identity, then commit RECORD_COUNT objects
+#   strand-locks    scale the Ledger down and leave unreleased Auditor asset locks behind. It
+#                   leaves the Ledger at 0 replicas; `manage-cluster.sh upgrade` brings it back
+#   write-metadata  record what was populated, for the verification step to read back
+#
+# Required environment:
+#   CLIENT        path to the ScalarDL HashStore CLI (the OLD version: the garbage is created by
+#                 the old client)
+#   RECORD_COUNT  records generated per category
+#   RUNNER_TEMP   scratch directory (metadata mode only)
+#
+# Usage:
+#   ./populate.sh commit-objects | strand-locks | write-metadata
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# LEDGER_NS / AUDITOR_NS and require_vars come from common.sh; pf_* from port-forward.sh.
+source "$HERE/common.sh"
+source "$HERE/port-forward.sh"
+
+# client.properties resolves the Auditor CA cert relative to scalardl-cleanup/.
+cd "$HERE/../.."
+
+props="$HERE/client.properties"
+
+LOCK_VALID_PERIOD_SECS=15
+
+commit_objects() {
+  pf_reset
+  pf_start "$LEDGER_NS"  svc/ledger  50051:50051 50052:50052
+  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+  pf_wait 50051 50052 40051 40052
+  # Register the client identity + the generic object contracts on both servers.
+  "$CLIENT" bootstrap --properties "$props"
+  # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)
+  # produces asset / request_proof / coordinator.state / released asset_lock records.
+  for i in $(seq 0 $((RECORD_COUNT - 1))); do
+    id="e2e-asset-$i"
+    hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+    "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"
+  done
+}
+
+strand_locks() {
+  pf_reset
+  "$HERE/manage-cluster.sh" stop-ledger
+  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+  pf_wait 40051 40052
+  # Every op MUST fail (Ledger down): the Auditor is left holding the lock. Fail the job if
+  # any unexpectedly succeeds. put-object leaves a WRITE lock on a fresh id; get-object leaves
+  # a READ lock on an already-committed id.
+  for i in $(seq 0 $((RECORD_COUNT - 1))); do
+    id="e2e-stranded-$i"
+    hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+    if "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
+      echo "::error::stranded put-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
+    fi
+  done
+  for i in $(seq 0 $((RECORD_COUNT - 1))); do
+    id="e2e-asset-$i"
+    if "$CLIENT" get-object --properties "$props" --object-id "$id"; then
+      echo "::error::stranded get-object on $id unexpectedly succeeded (Ledger was supposed to be down)"; exit 1
+    fi
+  done
+  echo "Waiting $((LOCK_VALID_PERIOD_SECS + 1))s for the held locks to pass the ${LOCK_VALID_PERIOD_SECS}s valid period ..."
+  sleep $((LOCK_VALID_PERIOD_SECS + 1))
+}
+
+# Record what was populated. The verify step reads this back (single source of truth for the
+# asset ids), and it is uploaded as an artifact for inspection. strandedReadAssetIds are the
+# committed ids that also received a stranded READ lock (== committedAssetIds here).
+write_metadata() {
+  jq -n --argjson n "$RECORD_COUNT" '{
+    entityId: "e2e-client",
+    committedAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
+    strandedAssetIds: [range(0; $n) | "e2e-stranded-\(.)"],
+    strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"]
+  }' > "$RUNNER_TEMP/populated-assets.json"
+}
+
+case "${1:-}" in
+  commit-objects)
+    require_vars CLIENT RECORD_COUNT
+    commit_objects
+    ;;
+  strand-locks)
+    require_vars CLIENT RECORD_COUNT
+    strand_locks
+    ;;
+  write-metadata)
+    require_vars RECORD_COUNT RUNNER_TEMP
+    write_metadata
+    ;;
+  *)
+    echo "usage: populate.sh [commit-objects|strand-locks|write-metadata]" >&2
+    exit 1
+    ;;
+esac

--- a/scalardl-cleanup/ci/e2e/populate.sh
+++ b/scalardl-cleanup/ci/e2e/populate.sh
@@ -29,6 +29,7 @@ cd "$HERE/../.."
 
 props="$HERE/client.properties"
 
+# Mirrors LockOrderRecoveryHandler.LOCK_VALID_PERIOD_MILLIS in scalardl-enterprise.
 LOCK_VALID_PERIOD_SECS=15
 
 commit_objects() {

--- a/scalardl-cleanup/ci/e2e/populate.sh
+++ b/scalardl-cleanup/ci/e2e/populate.sh
@@ -34,9 +34,7 @@ LOCK_VALID_PERIOD_SECS=15
 
 commit_objects() {
   pf_reset
-  pf_start "$LEDGER_NS"  svc/ledger  50051:50051 50052:50052
-  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
-  pf_wait 50051 50052 40051 40052
+  pf_start_all
   # Register the client identity + the generic object contracts on both servers.
   "$CLIENT" bootstrap --properties "$props"
   # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)

--- a/scalardl-cleanup/ci/e2e/port-forward.sh
+++ b/scalardl-cleanup/ci/e2e/port-forward.sh
@@ -3,10 +3,16 @@
 # Shared kubectl port-forward helpers for the E2E test cluster. Usage:
 #
 #   source ci/e2e/port-forward.sh
-#   pf_reset # kill leftovers from prior steps
-#   pf_start "$LNS" svc/ledger  50051:50051 50052:50052
-#   pf_start "$ANS" svc/auditor 40051:40051 40052:40052
-#   pf_wait 50051 50052 40051 40052 # block until reachable
+#   pf_reset       # kill leftovers from prior steps
+#   pf_start_all   # forward both servers and block until reachable
+#
+# Or drive a single server, as the stranded-lock population does while the Ledger is down:
+#
+#   pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+#   pf_wait 40051 40052
+
+# LEDGER_NS / AUDITOR_NS, which pf_start_all needs, come from here.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 # TCP connect check via a bash builtin.
 pf_check_tcp() { timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; }
@@ -46,4 +52,12 @@ pf_wait() {
       return 1
     }
   done
+}
+
+# Start the forwards both servers need and block until they are reachable.
+# Usage: pf_start_all
+pf_start_all() {
+  pf_start "$LEDGER_NS"  svc/ledger  50051:50051 50052:50052
+  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+  pf_wait 50051 50052 40051 40052
 }

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -1,84 +1,64 @@
 #!/usr/bin/env bash
 #
-# Run the three ScalarDL Cleanup commands against the deployed E2E cluster the way an operator does:
+# The three operator-facing ScalarDL Cleanup commands, each run as a Kubernetes Job from
+# scalardl-cleanup/manifests. Source it:
 #
-#   Step 1 (Ledger AD)  credentials Secret -> checkpoint PVC -> ConfigMap -> finalize-ledger Job
-#   Step 2 (Auditor AD) credentials Secret -> checkpoint PVC -> ConfigMap (+ TLS optional settings)
-#                       -> finalize-auditor Job
-#   Step 3 (Ledger AD)  cleanup-coordinator Job, with both completion tokens
+#   source ci/e2e/run-cleanup.sh
 #
 # Expects in the environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
 #   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
-#   RUNNER_TEMP      scratch directory for the rendered ConfigMaps
-#   RECORD_COUNT     number of records populated per category
+#   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
+#
+# A function fails if its command cannot be carried out, but never judges the result: whether what
+# a command reclaimed is what the test expects is the scenario's call.
 
-set -euo pipefail
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$E2E_DIR/cleanup-jobs.sh"
 
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/cleanup-jobs.sh"
+# Prepare what every step needs. Call once, before the first step.
+init_cleanup_commands() {
+  require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP
 
-require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
+  # The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
+  # passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
+  export CLEANUP_VERSION
 
-# The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
-# passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
-export CLEANUP_VERSION
+  init_manifests_workdir
+  load_ad_credentials
+}
 
-init_manifests_workdir
-load_ad_credentials
+# Run finalize-ledger (Ledger AD). Sets ledger_token.
+run_finalize_ledger() {
+  local out
+  setup_ledger_ad
+  apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
+  wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
+  out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
+  echo "finalize-ledger output: $out"
+  ledger_token=$(extract_completion_token finalize-ledger "$out")
+}
 
-# --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
-echo "== Step 1: finalize-ledger =="
+# Run finalize-auditor (Auditor AD). Sets auditor_token. Recovering a stranded lock can wait out the
+# lock's valid period, hence the longer timeout.
+run_finalize_auditor() {
+  local out
+  setup_auditor_ad
+  apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
+  wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
+  out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
+  echo "finalize-auditor output: $out"
+  auditor_token=$(extract_completion_token finalize-auditor "$out")
+}
 
-setup_ledger_ad
-
-# Run the Job.
-apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
-wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
-ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
-echo "finalize-ledger output: $ledger_out"
-token_l=$(extract_completion_token finalize-ledger "$ledger_out")
-
-# --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
-echo "== Step 2: finalize-auditor =="
-
-setup_auditor_ad
-
-# Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
-# timeout.
-rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
-wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
-auditor_out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
-echo "finalize-auditor output: $auditor_out"
-token_a=$(extract_completion_token finalize-auditor "$auditor_out")
-rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-echo "request_proof rows: before=$rp_before after=$rp_after"
-[ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
-
-# --- Step 3 (Ledger AD): cleanup-coordinator ---------------------------------------------------
-echo "== Step 3: cleanup-coordinator =="
-
-# The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
-export LEDGER_TOKEN="$token_l" AUDITOR_TOKEN="$token_a"
-
-cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
-wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
-coord_out=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
-echo "cleanup-coordinator output: $coord_out"
-[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
-  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
-
-cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-# Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
-# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
-# writing coordinator.state rows after the boundary, which survive and are not counted here.
-echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
-[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
-  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
-[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
-  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
-
-echo "All three cleanup commands succeeded."
+# Run cleanup-coordinator (Ledger AD). Sets cleanup_coordinator_output to the command's JSON.
+# Usage: run_cleanup_coordinator <ledger-token> <auditor-token>
+run_cleanup_coordinator() {
+  # The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
+  export LEDGER_TOKEN="$1" AUDITOR_TOKEN="$2"
+  apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
+  wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
+  cleanup_coordinator_output=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
+  echo "cleanup-coordinator output: $cleanup_coordinator_output"
+}

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -17,121 +17,23 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/common.sh"
+source "$HERE/cleanup-jobs.sh"
 
 require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
 
 # The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
-# passed to kubectl instead. LEDGER_NS / AUDITOR_NS / AUDITOR_TLS_SAN come from common.sh exported.
+# passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
 export CLEANUP_VERSION
 
-MANIFESTS="$HERE/../../manifests"
-
-# Working copy of the manifests, one directory per administrative domain as in the source tree.
-work="$RUNNER_TEMP/manifests"
-rm -rf "$work"
-mkdir -p "$work"
-cp -R "$MANIFESTS/ledger-ad" "$MANIFESTS/auditor-ad" "$work/"
-
-ledger_props="$RUNNER_TEMP/ledger.properties"
-auditor_props="$RUNNER_TEMP/auditor.properties"
-
-# Read a single property value from a properties file.
-# Usage: read_prop_value <file> <key>
-read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
-
-# Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
-# from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
-# and keeps this script free of secrets of its own.
-kubectl -n "$LEDGER_NS"  get secret ledger-config  -o jsonpath='{.data.ledger\.properties}'  | base64 -d > "$ledger_props"
-kubectl -n "$AUDITOR_NS" get secret auditor-config -o jsonpath='{.data.auditor\.properties}' | base64 -d > "$auditor_props"
-ledger_uri=$(read_prop_value "$ledger_props" scalar.db.contact_points)
-ledger_key=$(read_prop_value "$ledger_props" scalar.db.password)
-auditor_uri=$(read_prop_value "$auditor_props" scalar.db.contact_points)
-auditor_key=$(read_prop_value "$auditor_props" scalar.db.password)
-
-# Upsert an AD's credentials Secret. The Jobs pull it in with envFrom, so it has to exist before they
-# run. `create --dry-run=client | apply` is the upsert: a plain `create` fails once it exists.
-# Usage: upsert_credentials_secret <namespace> <cosmos-key>
-upsert_credentials_secret() {
-  kubectl -n "$1" create secret generic scalardl-cleanup-credentials \
-    --from-literal=SCALAR_DB_PASSWORD="$2" \
-    --dry-run=client -o yaml | kubectl apply -f -
-}
-
-# Apply a Job manifest, dropping any leftover of the same name first: Jobs are immutable, so a
-# re-run of this script would otherwise fail on apply. As in manage-cluster.sh, give envsubst an
-# explicit variable list so it substitutes ONLY these placeholders and never rewrites a literal
-# $VAR that later lands in a manifest. The tokens are unset until Step 3 and expand to empty, but
-# the finalize manifests never reference them.
-# Usage: apply_job <namespace> <job> <manifest>
-apply_job() {
-  kubectl -n "$1" delete "job/$2" --ignore-not-found
-  envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
-}
-
-# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
-# stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
-# JSON line out of the log4j lines around it.
-# Usage: read_job_output_json <namespace> <job>
-read_job_output_json() {
-  local ns="$1" job="$2" pod json
-  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
-    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
-  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
-  json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
-  [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
-  printf '%s\n' "$json"
-}
-
-# Extract a non-empty completion token from a finalize command's JSON output, or fail.
-# Usage: extract_completion_token <command-name> <json>
-extract_completion_token() {
-  local name="$1" json="$2" token
-  token=$(printf '%s' "$json" | jq -r '.output.completion_token // empty')
-  [ -n "$token" ] || { echo "::error::$name emitted no completion token" >&2; return 1; }
-  printf '%s\n' "$token"
-}
-
-# Count items in a container, authenticating with the given account endpoint and key.
-# Usage: count_cosmos_items <endpoint> <key> <database> <container>
-count_cosmos_items() {
-  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
-  output=$("$COSMOSDB_SHELL" <<EOF
-connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
-cd ${database}
-cd ${container}
-query "SELECT * FROM c" | jq '.items | length'
-exit
-EOF
-)
-  # Extract the count integer from the shell output, and fail if none is found. `|| true` keeps a
-  # no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the empty-check below
-  # can report a useful error.
-  count=$(printf '%s\n' "$output" | grep -oxE '[0-9]+' | tail -n1 || true)
-  if [ -z "$count" ]; then
-    echo "::error::could not parse a row count for ${database}/${container} from Cosmos DB Shell output" >&2
-    printf '%s\n' "$output" >&2
-    return 1
-  fi
-  printf '%s\n' "$count"
-}
+init_manifests_workdir
+load_ad_credentials
 
 # --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
 echo "== Step 1: finalize-ledger =="
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
+setup_ledger_ad
 
-# (b) Create the checkpoint volume.
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/pvc.yaml"
-
-# (c) Apply the ConfigMap, substituting contact_points first.
-sed "s|<cosmos-account-uri>|$ledger_uri|" \
-  "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
-kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
-
-# (d) Run the Job.
+# Run the Job.
 apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
 wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
 ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
@@ -141,29 +43,9 @@ token_l=$(extract_completion_token finalize-ledger "$ledger_out")
 # --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
 echo "== Step 2: finalize-auditor =="
 
-# (a) Create the credentials Secret.
-upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
+setup_auditor_ad
 
-# (b) Create the checkpoint volume.
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/pvc.yaml"
-
-# (c) Apply the ConfigMap, substituting contact_points and the Auditor host first. The E2E Auditor
-# serves TLS, so uncomment the tls.* lines too and pin its cert SAN, which the host above is not.
-sed -E \
-  -e "s|<cosmos-account-uri>|$auditor_uri|" \
-  -e "s|<auditor-host>|auditor|" \
-  -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
-  -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
-  "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
-kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
-
-# Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
-# Auditor's server cert. manage-cluster.sh generated that self-signed cert at deploy time.
-kubectl -n "$AUDITOR_NS" create secret generic scalardl-cleanup-cert \
-  --from-file=tls.crt="$CERTS_DIR/auditor.crt" \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-# (d) Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
+# Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
 # timeout.
 rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
 apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Scenario: every command in run-cleanup.sh, in the documented apply order, against a cluster
+# holding both committed data and stranded Auditor locks.
+#
+# Required environment:
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   CLIENT           path to the ScalarDL HashStore CLI
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RECORD_COUNT     records generated per category
+#   RUNNER_TEMP      scratch directory for the rendered manifests and the populated-assets
+#                    metadata
+# and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E="$HERE/.."
+source "$E2E/common.sh"
+source "$E2E/port-forward.sh"
+source "$E2E/run-cleanup.sh"
+
+# client.properties resolves the Auditor CA cert relative to scalardl-cleanup/.
+cd "$E2E/../.."
+
+props="$E2E/client.properties"
+
+require_vars CLIENT RUNNER_TEMP RECORD_COUNT
+
+echo "== Run the cleanup commands =="
+
+init_cleanup_commands
+
+run_finalize_ledger
+
+rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+run_finalize_auditor
+rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+echo "request_proof rows: before=$rp_before after=$rp_after"
+[ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
+
+cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+run_cleanup_coordinator "$ledger_token" "$auditor_token"
+[ "$(printf '%s' "$cleanup_coordinator_output" | jq -r '.status_code')" = "OK" ] \
+  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
+
+cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+# Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
+# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
+# writing coordinator.state rows after the boundary, which survive and are not counted here.
+echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
+[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
+  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
+[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
+  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
+
+echo "== Verify post-cleanup consistency =="
+pf_reset
+pf_start_all
+populated="$RUNNER_TEMP/populated-assets.json"
+
+# Read the ids up front rather than piping jq straight into the loop: a process substitution's exit
+# status is invisible to `set -e`, so a missing or malformed file would run the loop zero times and
+# report success. An empty list means the same thing, and is just as fatal.
+[ -s "$populated" ] || { echo "::error::$populated is missing or empty"; exit 1; }
+ids=$(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated") \
+  || { echo "::error::could not read the asset ids from $populated"; exit 1; }
+[ -n "$ids" ] || { echo "::error::$populated lists no asset ids to verify"; exit 1; }
+count=$(printf '%s\n' "$ids" | wc -l | tr -d ' ')
+# Both populated categories are RECORD_COUNT long, so a short list means a truncated file.
+[ "$count" -eq "$((2 * RECORD_COUNT))" ] \
+  || { echo "::error::$populated lists $count asset ids (expected $((2 * RECORD_COUNT)))"; exit 1; }
+echo "Verifying $count assets ..."
+
+# After cleanup, every asset must be fully usable again: writable, readable, and passing
+# ledger validation.
+while IFS= read -r id; do
+  hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+  if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
+    echo "::error::put-object on $id failed after cleanup"; exit 1
+  fi
+  if ! "$CLIENT" get-object --properties "$props" --object-id "$id"; then
+    echo "::error::get-object on $id failed after cleanup"; exit 1
+  fi
+  if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
+    echo "::error::validate-ledger on $id failed after cleanup"; exit 1
+  fi
+done <<< "$ids"
+
+echo "Post-cleanup consistency verified."


### PR DESCRIPTION
## Description

This PR moves the E2E data population from inline `run:` blocks in `e2e.yaml` into a script.

The scenario harness that follows has to set up the same data for each scenario run, and inline bash in a workflow step cannot be called from anywhere — only that step runs it once. This is a pure refactoring: no assertions are added and no behavior changes.

## Related issues and/or PRs

- #73 

## Changes made

- Add `ci/e2e/populate.sh` with the population steps extracted from `e2e.yaml`.
- Reduce the three workflow steps to one-line calls into it.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A