### PR TITLE
Restructure the E2E test around scenario scripts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,15 +7,8 @@ name: E2E
 #      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
 #   2. Upgrade both servers in place to the new version (which exposes the privileged
 #      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the three operator-facing cleanup subcommands against the upgraded cluster, deployed the
-#      way an operator deploys them: as Kubernetes Jobs from scalardl-cleanup/manifests, in the
-#      documented apply order (so the deployment procedure is under test too).
-#        finalize-ledger      -> emits the Ledger completion token
-#        finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and
-#                                cleans up request_proof; emits the Auditor completion token
-#        cleanup-coordinator  -> deletes the settled coordinator.state records
-#   4. Assert, at the ScalarDL application layer, that every existing asset is writable, readable,
-#      and passes validate-ledger.
+#   3. Run the scenario script in ci/e2e/scenarios as a single workflow step. It drives the cleanup
+#      commands and asserts on the outcome; its own header documents what it covers.
 #
 # CI-only. Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
@@ -137,35 +130,8 @@ jobs:
           SCALARDL_VERSION: ${{ env.SCALARDL_NEW_VERSION }}
         run: ./ci/e2e/manage-cluster.sh upgrade
 
-      - name: Run the cleanup commands as Kubernetes Jobs
-        run: ./ci/e2e/run-cleanup.sh
-
-      - name: Verify post-cleanup consistency
-        run: |
-          set -euo pipefail
-          source ci/e2e/port-forward.sh
-          pf_reset
-          pf_start ledger-e2e  svc/ledger  50051:50051 50052:50052
-          pf_start auditor-e2e svc/auditor 40051:40051 40052:40052
-          pf_wait 50051 50052 40051 40052
-          props="ci/e2e/client.properties"
-          populated="$RUNNER_TEMP/populated-assets.json"
-
-          # After cleanup, every asset must be fully usable again: writable, readable, and passing
-          # ledger validation.
-          while IFS= read -r id; do
-            hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
-            if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
-              echo "::error::put-object on $id failed after cleanup"; exit 1
-            fi
-            if ! "$CLIENT" get-object --properties "$props" --object-id "$id"; then
-              echo "::error::get-object on $id failed after cleanup"; exit 1
-            fi
-            if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
-              echo "::error::validate-ledger on $id failed after cleanup"; exit 1
-            fi
-          done < <(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated")
-          echo "Post-cleanup consistency verified."
+      - name: Run scenario - happy path
+        run: ./ci/e2e/scenarios/happy-path.sh
 
       - name: Upload populated-assets
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,8 +7,7 @@ name: E2E
 #      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
 #   2. Upgrade both servers in place to the new version (which exposes the privileged
 #      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the scenario script in ci/e2e/scenarios as a single workflow step. It drives the cleanup
-#      commands and asserts on the outcome; its own header documents what it covers.
+#   3. Run the scenario script in ci/e2e/scenarios.
 #
 # CI-only. Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
@@ -71,8 +70,7 @@ jobs:
         run: ./gradlew :cli:docker -PdockerVersion="$CLEANUP_VERSION"
 
       - name: Install Azure Cosmos DB Shell
-        # Used by run-cleanup.sh to count rows directly in Cosmos for the post-cleanup reclamation
-        # checks.
+        # Used by the scenarios to count rows directly in Cosmos for their reclamation checks.
         run: |
           set -euo pipefail
           v=1.1.4

--- a/scalardl-cleanup/ci/e2e/manage-cluster.sh
+++ b/scalardl-cleanup/ci/e2e/manage-cluster.sh
@@ -36,7 +36,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Namespaces, the Auditor TLS SAN, CERTS_DIR, and the kubectl helpers (require_vars,
-# wait_for_job, diag_and_die) live here so run-cleanup.sh sees exactly the same values.
+# wait_for_job, diag_and_die) live here so every script in ci/e2e sees the same values.
 source "$HERE/common.sh"
 
 SCALARDL_VERSION_EXPLICIT="${SCALARDL_VERSION:+yes}"   # "yes" if set and non-empty, else ""

--- a/scalardl-cleanup/ci/e2e/populate.sh
+++ b/scalardl-cleanup/ci/e2e/populate.sh
@@ -34,9 +34,7 @@ LOCK_VALID_PERIOD_SECS=15
 
 commit_objects() {
   pf_reset
-  pf_start "$LEDGER_NS"  svc/ledger  50051:50051 50052:50052
-  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
-  pf_wait 50051 50052 40051 40052
+  pf_start_all
   # Register the client identity + the generic object contracts on both servers.
   "$CLIENT" bootstrap --properties "$props"
   # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)

--- a/scalardl-cleanup/ci/e2e/port-forward.sh
+++ b/scalardl-cleanup/ci/e2e/port-forward.sh
@@ -3,10 +3,16 @@
 # Shared kubectl port-forward helpers for the E2E test cluster. Usage:
 #
 #   source ci/e2e/port-forward.sh
-#   pf_reset # kill leftovers from prior steps
-#   pf_start "$LNS" svc/ledger  50051:50051 50052:50052
-#   pf_start "$ANS" svc/auditor 40051:40051 40052:40052
-#   pf_wait 50051 50052 40051 40052 # block until reachable
+#   pf_reset       # kill leftovers from prior steps
+#   pf_start_all   # forward both servers and block until reachable
+#
+# Or drive a single server, as the stranded-lock population does while the Ledger is down:
+#
+#   pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+#   pf_wait 40051 40052
+
+# LEDGER_NS / AUDITOR_NS, which pf_start_all needs, come from here.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 # TCP connect check via a bash builtin.
 pf_check_tcp() { timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; }
@@ -46,4 +52,12 @@ pf_wait() {
       return 1
     }
   done
+}
+
+# Start the forwards both servers need and block until they are reachable.
+# Usage: pf_start_all
+pf_start_all() {
+  pf_start "$LEDGER_NS"  svc/ledger  50051:50051 50052:50052
+  pf_start "$AUDITOR_NS" svc/auditor 40051:40051 40052:40052
+  pf_wait 50051 50052 40051 40052
 }

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -1,84 +1,60 @@
 #!/usr/bin/env bash
 #
-# Run the three ScalarDL Cleanup commands against the deployed E2E cluster the way an operator does:
+# The three operator-facing ScalarDL Cleanup commands, each run as a Kubernetes Job from
+# scalardl-cleanup/manifests. Source it:
 #
-#   Step 1 (Ledger AD)  credentials Secret -> checkpoint PVC -> ConfigMap -> finalize-ledger Job
-#   Step 2 (Auditor AD) credentials Secret -> checkpoint PVC -> ConfigMap (+ TLS optional settings)
-#                       -> finalize-auditor Job
-#   Step 3 (Ledger AD)  cleanup-coordinator Job, with both completion tokens
+#   source ci/e2e/run-cleanup.sh
 #
 # Expects in the environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
 #   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
 #   RUNNER_TEMP      scratch directory for the rendered ConfigMaps
-#   RECORD_COUNT     number of records populated per category
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 
-set -euo pipefail
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$E2E_DIR/cleanup-jobs.sh"
 
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/cleanup-jobs.sh"
+# Prepare what every step needs. Call once, before the first step.
+init_cleanup_commands() {
+  require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP
 
-require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP RECORD_COUNT
+  # The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
+  # passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
+  export CLEANUP_VERSION
 
-# The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
-# passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
-export CLEANUP_VERSION
+  init_manifests_workdir
+  load_ad_credentials
+}
 
-init_manifests_workdir
-load_ad_credentials
+# Run finalize-ledger (Ledger AD). Echoes the completion token.
+run_finalize_ledger() {
+  local out
+  setup_ledger_ad >&2
+  apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml" >&2
+  wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600 >&2
+  out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
+  echo "finalize-ledger output: $out" >&2
+  extract_completion_token finalize-ledger "$out"
+}
 
-# --- Step 1 (Ledger AD): finalize-ledger -------------------------------------------------------
-echo "== Step 1: finalize-ledger =="
+# Run finalize-auditor (Auditor AD). Echoes the completion token. Recovering a stranded lock can
+# wait out the lock's valid period, hence the longer timeout.
+run_finalize_auditor() {
+  local out
+  setup_auditor_ad >&2
+  apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml" >&2
+  wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900 >&2
+  out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
+  echo "finalize-auditor output: $out" >&2
+  extract_completion_token finalize-auditor "$out"
+}
 
-setup_ledger_ad
-
-# Run the Job.
-apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
-wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
-ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
-echo "finalize-ledger output: $ledger_out"
-token_l=$(extract_completion_token finalize-ledger "$ledger_out")
-
-# --- Step 2 (Auditor AD): finalize-auditor -----------------------------------------------------
-echo "== Step 2: finalize-auditor =="
-
-setup_auditor_ad
-
-# Run the Job. Recovering a stranded lock can wait out the lock's valid period, hence the longer
-# timeout.
-rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
-wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
-auditor_out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
-echo "finalize-auditor output: $auditor_out"
-token_a=$(extract_completion_token finalize-auditor "$auditor_out")
-rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-echo "request_proof rows: before=$rp_before after=$rp_after"
-[ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
-
-# --- Step 3 (Ledger AD): cleanup-coordinator ---------------------------------------------------
-echo "== Step 3: cleanup-coordinator =="
-
-# The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
-export LEDGER_TOKEN="$token_l" AUDITOR_TOKEN="$token_a"
-
-cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
-wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
-coord_out=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
-echo "cleanup-coordinator output: $coord_out"
-[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
-  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
-
-cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-# Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
-# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
-# writing coordinator.state rows after the boundary, which survive and are not counted here.
-echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
-[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
-  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
-[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
-  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
-
-echo "All three cleanup commands succeeded."
+# Run cleanup-coordinator (Ledger AD). Echoes the command's JSON output.
+# Usage: run_cleanup_coordinator <ledger-token> <auditor-token>
+run_cleanup_coordinator() {
+  # The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
+  export LEDGER_TOKEN="$1" AUDITOR_TOKEN="$2"
+  apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml" >&2
+  wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600 >&2
+  read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator
+}

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -8,8 +8,10 @@
 # Expects in the environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
 #   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
-#   RUNNER_TEMP      scratch directory for the rendered ConfigMaps
+#   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
+#
+# Nothing here asserts; each function reports its outcome through a global for the caller to judge.
 
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$E2E_DIR/cleanup-jobs.sh"
@@ -26,35 +28,35 @@ init_cleanup_commands() {
   load_ad_credentials
 }
 
-# Run finalize-ledger (Ledger AD). Echoes the completion token.
+# Run finalize-ledger (Ledger AD). Sets ledger_token.
 run_finalize_ledger() {
   local out
-  setup_ledger_ad >&2
-  apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml" >&2
-  wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600 >&2
+  setup_ledger_ad
+  apply_job "$LEDGER_NS" scalardl-finalize-ledger "$work/ledger-ad/finalize-ledger.yaml"
+  wait_for_job "$LEDGER_NS" scalardl-finalize-ledger 600
   out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
-  echo "finalize-ledger output: $out" >&2
-  extract_completion_token finalize-ledger "$out"
+  echo "finalize-ledger output: $out"
+  ledger_token=$(extract_completion_token finalize-ledger "$out")
 }
 
-# Run finalize-auditor (Auditor AD). Echoes the completion token. Recovering a stranded lock can
-# wait out the lock's valid period, hence the longer timeout.
+# Run finalize-auditor (Auditor AD). Sets auditor_token. Recovering a stranded lock can wait out the
+# lock's valid period, hence the longer timeout.
 run_finalize_auditor() {
   local out
-  setup_auditor_ad >&2
-  apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml" >&2
-  wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900 >&2
+  setup_auditor_ad
+  apply_job "$AUDITOR_NS" scalardl-finalize-auditor "$work/auditor-ad/finalize-auditor.yaml"
+  wait_for_job "$AUDITOR_NS" scalardl-finalize-auditor 900
   out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
-  echo "finalize-auditor output: $out" >&2
-  extract_completion_token finalize-auditor "$out"
+  echo "finalize-auditor output: $out"
+  auditor_token=$(extract_completion_token finalize-auditor "$out")
 }
 
-# Run cleanup-coordinator (Ledger AD). Echoes the command's JSON output.
+# Run cleanup-coordinator (Ledger AD). Sets cleanup_coordinator_output to the command's JSON.
 # Usage: run_cleanup_coordinator <ledger-token> <auditor-token>
 run_cleanup_coordinator() {
   # The Job manifest takes both tokens as ${LEDGER_TOKEN} / ${AUDITOR_TOKEN}.
   export LEDGER_TOKEN="$1" AUDITOR_TOKEN="$2"
-  apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml" >&2
-  wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600 >&2
-  read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator
+  apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
+  wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
+  cleanup_coordinator_output=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
 }

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -11,7 +11,8 @@
 #   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 #
-# Nothing here asserts; each function reports its outcome through a global for the caller to judge.
+# A function fails if its command cannot be carried out, but never judges the result: whether what
+# a command reclaimed is what the test expects is the scenario's call.
 
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$E2E_DIR/cleanup-jobs.sh"
@@ -59,4 +60,5 @@ run_cleanup_coordinator() {
   apply_job "$LEDGER_NS" scalardl-cleanup-coordinator "$work/ledger-ad/cleanup-coordinator.yaml"
   wait_for_job "$LEDGER_NS" scalardl-cleanup-coordinator 600
   cleanup_coordinator_output=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
+  echo "cleanup-coordinator output: $cleanup_coordinator_output"
 }

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -8,7 +8,8 @@
 #   CLIENT           path to the ScalarDL HashStore CLI
 #   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
 #   RECORD_COUNT     records generated per category
-#   RUNNER_TEMP      scratch directory holding the populated-assets metadata
+#   RUNNER_TEMP      scratch directory for the rendered manifests and the populated-assets
+#                    metadata
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 
 set -euo pipefail
@@ -30,18 +31,18 @@ echo "== Run the cleanup commands =="
 
 init_cleanup_commands
 
-token_l=$(run_finalize_ledger)
+run_finalize_ledger
 
 rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
-token_a=$(run_finalize_auditor)
+run_finalize_auditor
 rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
 echo "request_proof rows: before=$rp_before after=$rp_after"
 [ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
 
 cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
-coord_out=$(run_cleanup_coordinator "$token_l" "$token_a")
-echo "cleanup-coordinator output: $coord_out"
-[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
+run_cleanup_coordinator "$ledger_token" "$auditor_token"
+echo "cleanup-coordinator output: $cleanup_coordinator_output"
+[ "$(printf '%s' "$cleanup_coordinator_output" | jq -r '.status_code')" = "OK" ] \
   || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
 
 cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Scenario: the operator's cleanup procedure against a cluster holding both committed data and
+# stranded Auditor locks.
+#
+# It runs the three subcommands the way an operator deploys them -- as Kubernetes Jobs from
+# scalardl-cleanup/manifests, in the documented apply order, so the deployment procedure is under
+# test too:
+#   finalize-ledger      -> emits the Ledger completion token
+#   finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and cleans up
+#                           request_proof; emits the Auditor completion token
+#   cleanup-coordinator  -> deletes the settled coordinator.state records
+# and then asserts, at the ScalarDL application layer, that every populated asset is writable,
+# readable, and passes validate-ledger.
+#
+# A scenario is a self-contained script that the workflow runs as a single step: it drives what it
+# needs, asserts, and exits non-zero on the first failed assertion. Section markers are echoed so a
+# failure is locatable within the step's log.
+#
+# Required environment: what run-cleanup.sh needs (CLEANUP_VERSION, COSMOSDB_SHELL, RUNNER_TEMP,
+# RECORD_COUNT), plus CLIENT.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E="$HERE/.."
+source "$E2E/common.sh"
+source "$E2E/port-forward.sh"
+
+# client.properties resolves the Auditor CA cert relative to scalardl-cleanup/.
+cd "$E2E/../.."
+
+props="$E2E/client.properties"
+
+require_vars CLIENT RUNNER_TEMP RECORD_COUNT
+
+"$E2E/run-cleanup.sh"
+
+echo "== Verify post-cleanup consistency =="
+pf_reset
+pf_start_all
+populated="$RUNNER_TEMP/populated-assets.json"
+
+# Read the ids up front rather than piping jq straight into the loop: a process substitution's exit
+# status is invisible to `set -e`, so a missing or malformed file would run the loop zero times and
+# report success. An empty list means the same thing, and is just as fatal.
+[ -s "$populated" ] || { echo "::error::$populated is missing or empty"; exit 1; }
+ids=$(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated") \
+  || { echo "::error::could not read the asset ids from $populated"; exit 1; }
+[ -n "$ids" ] || { echo "::error::$populated lists no asset ids to verify"; exit 1; }
+count=$(printf '%s\n' "$ids" | wc -l | tr -d ' ')
+# Both populated categories are RECORD_COUNT long, so a short list means a truncated file.
+[ "$count" -eq "$((2 * RECORD_COUNT))" ] \
+  || { echo "::error::$populated lists $count asset ids (expected $((2 * RECORD_COUNT)))"; exit 1; }
+echo "Verifying $count assets ..."
+
+# After cleanup, every asset must be fully usable again: writable, readable, and passing
+# ledger validation.
+while IFS= read -r id; do
+  hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+  if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
+    echo "::error::put-object on $id failed after cleanup"; exit 1
+  fi
+  if ! "$CLIENT" get-object --properties "$props" --object-id "$id"; then
+    echo "::error::get-object on $id failed after cleanup"; exit 1
+  fi
+  if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
+    echo "::error::validate-ledger on $id failed after cleanup"; exit 1
+  fi
+done <<< "$ids"
+echo "Post-cleanup consistency verified."

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -41,7 +41,6 @@ echo "request_proof rows: before=$rp_before after=$rp_after"
 
 cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
 run_cleanup_coordinator "$ledger_token" "$auditor_token"
-echo "cleanup-coordinator output: $cleanup_coordinator_output"
 [ "$(printf '%s' "$cleanup_coordinator_output" | jq -r '.status_code')" = "OK" ] \
   || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
 

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -1,24 +1,15 @@
 #!/usr/bin/env bash
 #
-# Scenario: the operator's cleanup procedure against a cluster holding both committed data and
-# stranded Auditor locks.
+# Scenario: every command in run-cleanup.sh, in the documented apply order, against a cluster
+# holding both committed data and stranded Auditor locks.
 #
-# It runs the three subcommands the way an operator deploys them -- as Kubernetes Jobs from
-# scalardl-cleanup/manifests, in the documented apply order, so the deployment procedure is under
-# test too:
-#   finalize-ledger      -> emits the Ledger completion token
-#   finalize-auditor     -> recovers the stranded asset locks via RecoverAssetLock and cleans up
-#                           request_proof; emits the Auditor completion token
-#   cleanup-coordinator  -> deletes the settled coordinator.state records
-# and then asserts, at the ScalarDL application layer, that every populated asset is writable,
-# readable, and passes validate-ledger.
-#
-# A scenario is a self-contained script that the workflow runs as a single step: it drives what it
-# needs, asserts, and exits non-zero on the first failed assertion. Section markers are echoed so a
-# failure is locatable within the step's log.
-#
-# Required environment: what run-cleanup.sh needs (CLEANUP_VERSION, COSMOSDB_SHELL, RUNNER_TEMP,
-# RECORD_COUNT), plus CLIENT.
+# Required environment:
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   CLIENT           path to the ScalarDL HashStore CLI
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RECORD_COUNT     records generated per category
+#   RUNNER_TEMP      scratch directory holding the populated-assets metadata
+# and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 
 set -euo pipefail
 
@@ -26,6 +17,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E="$HERE/.."
 source "$E2E/common.sh"
 source "$E2E/port-forward.sh"
+source "$E2E/run-cleanup.sh"
 
 # client.properties resolves the Auditor CA cert relative to scalardl-cleanup/.
 cd "$E2E/../.."
@@ -34,7 +26,33 @@ props="$E2E/client.properties"
 
 require_vars CLIENT RUNNER_TEMP RECORD_COUNT
 
-"$E2E/run-cleanup.sh"
+echo "== Run the cleanup commands =="
+
+init_cleanup_commands
+
+token_l=$(run_finalize_ledger)
+
+rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+token_a=$(run_finalize_auditor)
+rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+echo "request_proof rows: before=$rp_before after=$rp_after"
+[ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
+
+cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+coord_out=$(run_cleanup_coordinator "$token_l" "$token_a")
+echo "cleanup-coordinator output: $coord_out"
+[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
+  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
+
+cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+# Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
+# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
+# writing coordinator.state rows after the boundary, which survive and are not counted here.
+echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
+[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
+  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
+[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
+  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
 
 echo "== Verify post-cleanup consistency =="
 pf_reset
@@ -68,4 +86,5 @@ while IFS= read -r id; do
     echo "::error::validate-ledger on $id failed after cleanup"; exit 1
   fi
 done <<< "$ids"
+
 echo "Post-cleanup consistency verified."


### PR DESCRIPTION
## Description

This PR moves the E2E test's cleanup run and its post-cleanup verification into a scenario script, establishing the convention that the scenarios that follow will use one self-contained script per scenario, run as one workflow step. Apart from the verification fix below, no behavior changes.

## Related issues and/or PRs

- #74 

## Changes made

- Add `ci/e2e/scenarios/happy-path.sh` with the cleanup run and the post-cleanup verification, and reduce the two workflow steps to a single call into it.
- Fail the verification when the populated-assets metadata is missing, unreadable, or lists the wrong number of IDs.
- Add `pf_start_all()` utility to `port-forward.sh`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A