### PR TITLE
Report the solution in the error message

### DIFF
--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
@@ -166,7 +166,6 @@ public enum ScalarDlCleanupError implements ScalarDlToolsError {
     return cause;
   }
 
-  @SuppressWarnings("unused")
   @Override
   public String getSolution() {
     return solution;

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
@@ -59,14 +59,16 @@ public interface ScalarDlToolsError {
   /**
    * Builds the error message with the given arguments. The message is built as follows:
    *
-   * <p>{@code <componentName>-<categoryId><id>: <message>}
+   * <p>{@code <componentName>-<categoryId><id>: <message> <solution>}
    *
    * @param args the arguments to be formatted into the message
    * @return the formatted message
    */
   default String buildMessage(Object... args) {
-    return buildCode()
-        + ": "
-        + (args == null || args.length == 0 ? getMessage() : String.format(getMessage(), args));
+    String message =
+        buildCode()
+            + ": "
+            + (args == null || args.length == 0 ? getMessage() : String.format(getMessage(), args));
+    return getSolution().isEmpty() ? message : message + " " + getSolution();
   }
 }

--- a/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupErrorTest.java
+++ b/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupErrorTest.java
@@ -48,7 +48,14 @@ class ScalarDlCleanupErrorTest {
   }
 
   @Test
-  void buildMessage_noArgsGiven_shouldPrefixCodeToMessage() {
+  void values_shouldAllHaveSolution() {
+    for (ScalarDlCleanupError error : ScalarDlCleanupError.values()) {
+      assertThat(error.getSolution()).isNotEmpty();
+    }
+  }
+
+  @Test
+  void buildMessage_noArgsGiven_shouldPrefixCodeAndAppendSolution() {
     // Arrange
     ScalarDlCleanupError error = ScalarDlCleanupError.BOTH_COMPLETION_TOKENS_REQUIRED;
 
@@ -59,11 +66,12 @@ class ScalarDlCleanupErrorTest {
     assertThat(message)
         .isEqualTo(
             "DL-TOOLS-1004: Both Ledger and Auditor completion tokens are required for the "
-                + "initial run.");
+                + "initial run. Provide both the Ledger and Auditor completion tokens emitted by "
+                + "the finalization commands.");
   }
 
   @Test
-  void buildMessage_argsGiven_shouldFormatMessage() {
+  void buildMessage_argsGiven_shouldFormatMessageAndAppendSolution() {
     // Arrange
     ScalarDlCleanupError error = ScalarDlCleanupError.UNKNOWN_SERVER_TYPE;
 
@@ -72,6 +80,53 @@ class ScalarDlCleanupErrorTest {
 
     // Assert
     assertThat(message)
-        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+        .isEqualTo(
+            "DL-TOOLS-1003: Unknown server type in the completion token: foo. Verify that the "
+                + "completion token was copied verbatim and is not truncated or altered.");
+  }
+
+  @Test
+  void buildMessage_solutionEmptyGiven_shouldNotAppendTrailingSpace() {
+    // Arrange
+    ScalarDlToolsError error = new NoSolutionError();
+
+    // Act
+    String message = error.buildMessage();
+
+    // Assert
+    assertThat(message).isEqualTo("DL-TOOLS-1999: Something went wrong.");
+  }
+
+  /** A {@link ScalarDlToolsError} with no solution, which no {@link ScalarDlCleanupError} is. */
+  private static final class NoSolutionError implements ScalarDlToolsError {
+    @Override
+    public String getComponentName() {
+      return "DL-TOOLS";
+    }
+
+    @Override
+    public Category getCategory() {
+      return Category.USER_ERROR;
+    }
+
+    @Override
+    public String getId() {
+      return "999";
+    }
+
+    @Override
+    public String getMessage() {
+      return "Something went wrong.";
+    }
+
+    @Override
+    public String getCause() {
+      return "";
+    }
+
+    @Override
+    public String getSolution() {
+      return "";
+    }
   }
 }

--- a/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupExceptionTest.java
+++ b/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupExceptionTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 
 class ScalarDlCleanupExceptionTest {
 
+  // The assertions below match only the code-and-message prefix: buildMessage() also appends the
+  // solution, and that format is ScalarDlCleanupErrorTest's concern.
+
   @Test
   void constructor_errorGiven_shouldBuildMessageAndCarryCategory() {
     // Arrange & Act
@@ -14,7 +17,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-1007: The Auditor completion token is required for the initial run.");
+        .startsWith("DL-TOOLS-1007: The Auditor completion token is required for the initial run.");
     assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
   }
 
@@ -26,7 +29,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+        .startsWith("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
     assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
   }
 
@@ -41,7 +44,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-2001: Failed to load the state from /tmp/state.");
+        .startsWith("DL-TOOLS-2001: Failed to load the state from /tmp/state.");
     assertThat(exception.getCause()).isSameAs(cause);
     assertThat(exception.getCategory()).isEqualTo(Category.INTERNAL_ERROR);
   }


### PR DESCRIPTION
## Description

This PR makes `buildMessage()` append the error's solution. `getSolution()` was defined but never called, and the built message is all an operator sees — the CLI reports it as `error_message` and nothing else surfaces the error definition — so every suggested fix was being dropped on the floor.

## Related issues and/or PRs

N/A

## Changes made

- Append the solution to the built message, leaving a message without one unchanged.
- Updated unit tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A