### PR TITLE
Tell the operator to upgrade when the Auditor lacks RecoverAssetLock

### DIFF
--- a/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/main/java/com/scalar/dl/tools/cleanup/LockFinalizer.java
@@ -8,6 +8,7 @@ import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.ScalarDlCleanupError;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
+import io.grpc.Status;
 import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public final class LockFinalizer {
         AssetLockRecoveryRequest.newBuilder().setNamespace(namespace).setAssetId(assetId).build();
 
     for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      LockRecoveryResult rpcResult = auditorClient.recover(rpcRequest);
+      LockRecoveryResult rpcResult = recover(rpcRequest);
 
       if (rpcResult == LockRecoveryResult.SUCCEEDED || rpcResult == LockRecoveryResult.NOT_NEEDED) {
         return;
@@ -92,5 +93,21 @@ public final class LockFinalizer {
 
     throw new ScalarDlCleanupException(
         ScalarDlCleanupError.RECOVER_ASSET_LOCK_NOT_RECOVERABLE, assetId, namespace, MAX_ATTEMPTS);
+  }
+
+  /**
+   * Issues the RPC, translating the {@code UNIMPLEMENTED} status that an Auditor without {@code
+   * RecoverAssetLock} answers with.
+   */
+  private LockRecoveryResult recover(AssetLockRecoveryRequest rpcRequest) {
+    try {
+      return auditorClient.recover(rpcRequest);
+    } catch (RuntimeException e) {
+      if (Status.fromThrowable(e).getCode() == Status.Code.UNIMPLEMENTED) {
+        throw new ScalarDlCleanupException(
+            ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_UNSUPPORTED, e);
+      }
+      throw e;
+    }
   }
 }

--- a/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
+++ b/scalardl-cleanup/auditor-finalize-records/src/test/java/com/scalar/dl/tools/cleanup/LockFinalizerTest.java
@@ -11,11 +11,15 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.Result;
 import com.scalar.dl.auditor.ordering.LockRecoveryResult;
+import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.AuditorClient;
+import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.tools.common.AuditorInternalValues;
 import com.scalar.dl.tools.common.ScalarDlCleanupError;
 import com.scalar.dl.tools.common.ScalarDlCleanupException;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -80,6 +84,40 @@ class LockFinalizerTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(AuditorInternalValues.ASSET_LOCK_TABLE_ID_COLUMN_NAME);
     verify(auditorClient, never()).recover(any(AssetLockRecoveryRequest.class));
+  }
+
+  @Test
+  void execute_rpcUnimplementedGiven_shouldThrowPromptingAnUpgrade() {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenThrow(
+            new ClientException(
+                "UNIMPLEMENTED: Method not found: rpc.AuditorPrivileged/RecoverAssetLock",
+                new StatusRuntimeException(Status.UNIMPLEMENTED),
+                StatusCode.UNKNOWN_TRANSACTION_STATUS));
+
+    // Act & Assert
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(ScalarDlCleanupException.class)
+        .hasMessageContaining(ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_UNSUPPORTED.buildCode());
+  }
+
+  @Test
+  void execute_rpcFailsWithAnotherGrpcStatusGiven_shouldNotPromptAnUpgrade() {
+    // Arrange
+    when(auditorClient.recover(any(AssetLockRecoveryRequest.class)))
+        .thenThrow(
+            new ClientException(
+                "UNAVAILABLE: io exception",
+                new StatusRuntimeException(Status.UNAVAILABLE),
+                StatusCode.UNKNOWN_TRANSACTION_STATUS));
+
+    // Act & Assert
+    assertThatThrownBy(() -> finalizer.execute("default", createScanResult()))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("UNAVAILABLE")
+        .hasMessageNotContaining(
+            ScalarDlCleanupError.RECOVER_ASSET_LOCK_RPC_UNSUPPORTED.buildCode());
   }
 
   @Test

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
@@ -166,7 +166,6 @@ public enum ScalarDlCleanupError implements ScalarDlToolsError {
     return cause;
   }
 
-  @SuppressWarnings("unused")
   @Override
   public String getSolution() {
     return solution;

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlCleanupError.java
@@ -91,6 +91,13 @@ public enum ScalarDlCleanupError implements ScalarDlToolsError {
       "",
       "Verify that the configuration points to the database the Ledger uses and that the ScalarDL"
           + " schema has been loaded."),
+  RECOVER_ASSET_LOCK_RPC_UNSUPPORTED(
+      Category.USER_ERROR,
+      "014",
+      "The Auditor does not implement the RecoverAssetLock RPC that this command requires.",
+      "",
+      "Upgrade the Auditor to a version that implements RecoverAssetLock, then re-run the"
+          + " command."),
 
   //
   // Errors for the internal error category

--- a/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
+++ b/scalardl-cleanup/common/src/main/java/com/scalar/dl/tools/common/ScalarDlToolsError.java
@@ -59,14 +59,16 @@ public interface ScalarDlToolsError {
   /**
    * Builds the error message with the given arguments. The message is built as follows:
    *
-   * <p>{@code <componentName>-<categoryId><id>: <message>}
+   * <p>{@code <componentName>-<categoryId><id>: <message> <solution>}
    *
    * @param args the arguments to be formatted into the message
    * @return the formatted message
    */
   default String buildMessage(Object... args) {
-    return buildCode()
-        + ": "
-        + (args == null || args.length == 0 ? getMessage() : String.format(getMessage(), args));
+    String message =
+        buildCode()
+            + ": "
+            + (args == null || args.length == 0 ? getMessage() : String.format(getMessage(), args));
+    return getSolution().isEmpty() ? message : message + " " + getSolution();
   }
 }

--- a/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupErrorTest.java
+++ b/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupErrorTest.java
@@ -48,7 +48,14 @@ class ScalarDlCleanupErrorTest {
   }
 
   @Test
-  void buildMessage_noArgsGiven_shouldPrefixCodeToMessage() {
+  void values_shouldAllHaveSolution() {
+    for (ScalarDlCleanupError error : ScalarDlCleanupError.values()) {
+      assertThat(error.getSolution()).isNotEmpty();
+    }
+  }
+
+  @Test
+  void buildMessage_noArgsGiven_shouldPrefixCodeAndAppendSolution() {
     // Arrange
     ScalarDlCleanupError error = ScalarDlCleanupError.BOTH_COMPLETION_TOKENS_REQUIRED;
 
@@ -59,11 +66,12 @@ class ScalarDlCleanupErrorTest {
     assertThat(message)
         .isEqualTo(
             "DL-TOOLS-1004: Both Ledger and Auditor completion tokens are required for the "
-                + "initial run.");
+                + "initial run. Provide both the Ledger and Auditor completion tokens emitted by "
+                + "the finalization commands.");
   }
 
   @Test
-  void buildMessage_argsGiven_shouldFormatMessage() {
+  void buildMessage_argsGiven_shouldFormatMessageAndAppendSolution() {
     // Arrange
     ScalarDlCleanupError error = ScalarDlCleanupError.UNKNOWN_SERVER_TYPE;
 
@@ -72,6 +80,53 @@ class ScalarDlCleanupErrorTest {
 
     // Assert
     assertThat(message)
-        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+        .isEqualTo(
+            "DL-TOOLS-1003: Unknown server type in the completion token: foo. Verify that the "
+                + "completion token was copied verbatim and is not truncated or altered.");
+  }
+
+  @Test
+  void buildMessage_solutionEmptyGiven_shouldNotAppendTrailingSpace() {
+    // Arrange
+    ScalarDlToolsError error = new NoSolutionError();
+
+    // Act
+    String message = error.buildMessage();
+
+    // Assert
+    assertThat(message).isEqualTo("DL-TOOLS-1999: Something went wrong.");
+  }
+
+  /** A {@link ScalarDlToolsError} with no solution, which no {@link ScalarDlCleanupError} is. */
+  private static final class NoSolutionError implements ScalarDlToolsError {
+    @Override
+    public String getComponentName() {
+      return "DL-TOOLS";
+    }
+
+    @Override
+    public Category getCategory() {
+      return Category.USER_ERROR;
+    }
+
+    @Override
+    public String getId() {
+      return "999";
+    }
+
+    @Override
+    public String getMessage() {
+      return "Something went wrong.";
+    }
+
+    @Override
+    public String getCause() {
+      return "";
+    }
+
+    @Override
+    public String getSolution() {
+      return "";
+    }
   }
 }

--- a/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupExceptionTest.java
+++ b/scalardl-cleanup/common/src/test/java/com/scalar/dl/tools/common/ScalarDlCleanupExceptionTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 
 class ScalarDlCleanupExceptionTest {
 
+  // The assertions below match only the code-and-message prefix: buildMessage() also appends the
+  // solution, and that format is ScalarDlCleanupErrorTest's concern.
+
   @Test
   void constructor_errorGiven_shouldBuildMessageAndCarryCategory() {
     // Arrange & Act
@@ -14,7 +17,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-1007: The Auditor completion token is required for the initial run.");
+        .startsWith("DL-TOOLS-1007: The Auditor completion token is required for the initial run.");
     assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
   }
 
@@ -26,7 +29,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
+        .startsWith("DL-TOOLS-1003: Unknown server type in the completion token: foo.");
     assertThat(exception.getCategory()).isEqualTo(Category.USER_ERROR);
   }
 
@@ -41,7 +44,7 @@ class ScalarDlCleanupExceptionTest {
 
     // Assert
     assertThat(exception.getMessage())
-        .isEqualTo("DL-TOOLS-2001: Failed to load the state from /tmp/state.");
+        .startsWith("DL-TOOLS-2001: Failed to load the state from /tmp/state.");
     assertThat(exception.getCause()).isSameAs(cause);
     assertThat(exception.getCategory()).isEqualTo(Category.INTERNAL_ERROR);
   }


### PR DESCRIPTION
## Description

An Auditor without the `RecoverAssetLock` RPC makes `finalize-auditor` fail with gRPC's raw `UNIMPLEMENTED: Method not found: ...`, leaving the operator to work out that the fix is a server upgrade. This PR reports a user error that says so instead.

## Related issues and/or PRs

Depends on:

- #78 

## Changes made

- Add `RECOVER_ASSET_LOCK_RPC_UNSUPPORTED`, which names the missing RPC and tells the operator to upgrade the Auditor.
- Raise it from `LockFinalizer` when the exception chain carries gRPC's `UNIMPLEMENTED`, and let every other status propagate unchanged.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A