### PR TITLE
Add more E2E scenarios

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,13 +1,6 @@
 name: E2E
 
-# End-to-end test for ScalarDL Cleanup. The tool reclaims garbage left behind by an older ScalarDL
-# server, while coordinating with the upgraded server. This test reproduces exactly that:
-#
-#   1. Deploy ScalarDL Ledger + Auditor at the old version on minikube against a real Cosmos DB,
-#      load the schema, and populate committed + stranded data with the old client (HashStore CLI).
-#   2. Upgrade both servers in place to the new version (which exposes the privileged
-#      RecoverAssetLock RPC that finalize-auditor needs).
-#   3. Run the scenario script in ci/e2e/scenarios.
+# End-to-end test for ScalarDL Cleanup against a real Cosmos DB. Runs scenarios in ci/e2e/scenarios.
 #
 # CI-only. Requires repository secrets: COSMOS_URI, COSMOS_KEY, CR_PAT.
 
@@ -107,6 +100,7 @@ jobs:
         run: minikube image load "ghcr.io/scalar-labs/scalardl-cleanup:$CLEANUP_VERSION"
 
       - name: Deploy ScalarDL (old version) + load schema
+        id: deploy
         env:
           COSMOS_URI: ${{ secrets.COSMOS_URI }}
           COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
@@ -114,30 +108,27 @@ jobs:
           SCALARDL_VERSION: ${{ env.SCALARDL_OLD_VERSION }}
         run: ./ci/e2e/manage-cluster.sh deploy
 
-      - name: Populate committed data
-        run: ./ci/e2e/populate.sh commit-objects
-
-      - name: Generate stranded locks (Ledger down)
-        run: ./ci/e2e/populate.sh strand-locks
-
-      - name: Write populated-assets metadata
-        run: ./ci/e2e/populate.sh write-metadata
-
-      - name: Upgrade ScalarDL to the new version
+      - name: Run scenario - Auditor without RecoverAssetLock
         env:
-          SCALARDL_VERSION: ${{ env.SCALARDL_NEW_VERSION }}
-        run: ./ci/e2e/manage-cluster.sh upgrade
+          COSMOS_URI: ${{ secrets.COSMOS_URI }}
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+          RECORD_COUNT: 1
+        run: ./ci/e2e/scenarios/old-auditor.sh
 
       - name: Run scenario - happy path
+        if: ${{ !cancelled() && steps.deploy.outcome == 'success' }}
+        env:
+          COSMOS_URI: ${{ secrets.COSMOS_URI }}
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
         run: ./ci/e2e/scenarios/happy-path.sh
 
-      - name: Upload populated-assets
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-populated-assets
-          path: ${{ runner.temp }}/populated-assets.json
-          if-no-files-found: warn
+      - name: Run scenario - interrupt and resume
+        if: ${{ !cancelled() && steps.deploy.outcome == 'success' }}
+        env:
+          COSMOS_URI: ${{ secrets.COSMOS_URI }}
+          COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+          RECORD_COUNT: 20 # Enough rows that the scan is still running when the Pod is deleted.
+        run: ./ci/e2e/scenarios/interrupt-resume.sh
 
       - name: Collect diagnostics on failure
         if: failure()
@@ -163,7 +154,6 @@ jobs:
         env:
           COSMOS_URI: ${{ secrets.COSMOS_URI }}
           COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
-          CR_PAT: ${{ secrets.CR_PAT }}
           SCALARDL_VERSION: ${{ env.SCALARDL_OLD_VERSION }}
         # Fatal on purpose: the shared Cosmos account must be left clean, so a failed
         # drop fails the job to alert an operator (who then drops it manually).

--- a/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
+++ b/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
@@ -5,9 +5,10 @@
 #
 #   source ci/e2e/cleanup-jobs.sh
 #
-# Expects in the environment:
+# Required environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
-#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary (count_cosmos_records only, and it
+#                    checks for it itself)
 #   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed. It sets no shell
 # options of its own; the caller is expected to run under `set -euo pipefail`, which some of these
@@ -26,6 +27,7 @@ source "$E2E_DIR/common.sh"
 MANIFESTS="$E2E_DIR/../../manifests"
 
 # Working copy of the manifests, one directory per administrative domain as in the source tree.
+# Usage: init_manifests_workdir
 init_manifests_workdir() {
   work="$RUNNER_TEMP/manifests"
   rm -rf "$work"
@@ -40,6 +42,7 @@ read_prop_value() { grep -m1 "^$2=" "$1" | cut -d= -f2-; }
 # Each AD's Cosmos endpoint and key, taken from that AD's deployed server config. Reading them back
 # from the cluster points the cleanup Jobs at exactly the account and credentials their server uses,
 # and keeps these scripts free of secrets of their own.
+# Usage: load_ad_credentials
 load_ad_credentials() {
   ledger_props="$RUNNER_TEMP/ledger.properties"
   auditor_props="$RUNNER_TEMP/auditor.properties"
@@ -61,7 +64,22 @@ upsert_credentials_secret() {
     --dry-run=client -o yaml | kubectl apply -f -
 }
 
+# Append $extra_cleanup_properties, if a scenario set it, to a rendered ConfigMap. The properties
+# block is the last thing in both ConfigMaps, so appending at its indent is enough.
+# Usage: append_extra_properties <rendered-configmap>
+append_extra_properties() {
+  [ -n "${extra_cleanup_properties:-}" ] || return 0
+  # A key added after the block would leave valid YAML whose settings never reach the tool.
+  if [ -n "$(tail -n1 "$1" | sed -n '/^    [^ ]/p')" ]; then
+    printf '%s\n' "$extra_cleanup_properties" | sed 's/^/    /' >> "$1"
+  else
+    echo "::error::$1 does not end inside its properties block; cannot append settings" >&2
+    return 1
+  fi
+}
+
 # Prepare the Ledger AD for its Jobs.
+# Usage: setup_ledger_ad
 setup_ledger_ad() {
   # Create the credentials Secret.
   upsert_credentials_secret "$LEDGER_NS" "$ledger_key"
@@ -72,10 +90,12 @@ setup_ledger_ad() {
   # Apply the ConfigMap, substituting contact_points first.
   sed "s|<cosmos-account-uri>|$ledger_uri|" \
     "$MANIFESTS/ledger-ad/configmap.yaml" > "$work/ledger-ad/configmap.yaml"
+  append_extra_properties "$work/ledger-ad/configmap.yaml"
   kubectl -n "$LEDGER_NS" apply -f "$work/ledger-ad/configmap.yaml"
 }
 
 # Prepare the Auditor AD for its Jobs.
+# Usage: setup_auditor_ad
 setup_auditor_ad() {
   # Create the credentials Secret.
   upsert_credentials_secret "$AUDITOR_NS" "$auditor_key"
@@ -91,6 +111,7 @@ setup_auditor_ad() {
     -e "s|<auditor-cert-cn-or-san>|$AUDITOR_TLS_SAN|" \
     -e 's|^([[:space:]]*)#(scalar\.dl\.client\.auditor\.tls\.)|\1\2|' \
     "$MANIFESTS/auditor-ad/configmap.yaml" > "$work/auditor-ad/configmap.yaml"
+  append_extra_properties "$work/auditor-ad/configmap.yaml"
   kubectl -n "$AUDITOR_NS" apply -f "$work/auditor-ad/configmap.yaml"
 
   # Create the cert Secret that completes the TLS setup: it holds the CA root cert that signed the
@@ -111,18 +132,108 @@ apply_job() {
   envsubst '${CLEANUP_VERSION} ${LEDGER_TOKEN} ${AUDITOR_TOKEN}' < "$3" | kubectl -n "$1" apply -f -
 }
 
-# Echo the tool's JSON output from the succeeded Pod of a completed Job. The tool prints its JSON on
+# Echo the tool's JSON output from the Job's Pod in the given phase. The tool prints its JSON on
 # stdout and its logs on stderr, which `kubectl logs` merges, so `jq -R 'fromjson?'` is what picks the
 # JSON line out of the log4j lines around it.
-# Usage: read_job_output_json <namespace> <job>
-read_job_output_json() {
-  local ns="$1" job="$2" pod json
-  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
-    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
-  [ -n "$pod" ] || { echo "::error::no succeeded Pod found for job/$job in $ns" >&2; return 1; }
+# Usage: read_job_json <namespace> <job> <pod-phase>
+read_job_json() {
+  local ns="$1" job="$2" phase="$3" pod json
+  # A Job that retried has several Pods in the same phase, and they all carry the same outcome, so
+  # sort to pick the same one every time rather than whichever the API server lists first.
+  pod=$(kubectl -n "$ns" get pod -l "job-name=$job" --field-selector=status.phase="$phase" \
+    --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pod" ] || { echo "::error::no $phase Pod found for job/$job in $ns" >&2; return 1; }
   json=$(kubectl -n "$ns" logs "$pod" | jq -Rc 'fromjson? | select(type == "object")' | tail -n1)
   [ -n "$json" ] || { echo "::error::job/$job printed no JSON output" >&2; return 1; }
   printf '%s\n' "$json"
+}
+
+# Echo the JSON output of a completed Job.
+# Usage: read_job_output_json <namespace> <job>
+read_job_output_json() { read_job_json "$1" "$2" Succeeded; }
+
+# Run a Job that is expected to fail and echo the error JSON it printed. The manifest's backoffLimit
+# applies, so the failure is retried to exhaustion, as an operator would see. Progress output goes
+# to stderr, out of the caller's command substitution.
+# Usage: run_job_expect_failure <namespace> <job> <manifest> [timeout]
+run_job_expect_failure() {
+  local ns="$1" job="$2" manifest="$3" timeout="${4:-600}"
+  apply_job "$ns" "$job" "$manifest" >&2
+  wait_for_job_failure "$ns" "$job" "$timeout" >&2
+  read_job_json "$ns" "$job" Failed
+}
+
+# Empty an AD's checkpoint volume so the next command starts a fresh run. The Jobs' Pods hold the
+# PVC, so they go first and are waited for; setup_ledger_ad / setup_auditor_ad recreate it.
+# Usage: reset_checkpoint <namespace>
+reset_checkpoint() {
+  local ns="$1"
+  kubectl -n "$ns" delete job -l app.kubernetes.io/name=scalardl-cleanup \
+    --ignore-not-found --cascade=foreground --timeout=120s
+  kubectl -n "$ns" delete pvc scalardl-cleanup-checkpoint --ignore-not-found --timeout=120s
+}
+
+# Run a Job, kill the Pod once it logs the caller's marker, and let the Job's own backoffLimit start
+# the Pod that resumes: the checkpoint PVC outlives the Pod. Writes the killed Pod's log to
+# $RUNNER_TEMP/<job>-interrupted.log and the succeeding Pod's to <job>-resumed.log.
+# Usage: interrupt_and_resume <namespace> <job> <manifest> <started-marker> [timeout]
+interrupt_and_resume() {
+  local ns="$1" job="$2" manifest="$3" marker="$4" timeout="${5:-900}"
+  local first="" resuming="" before="" ok_pod pod names n deadline
+  apply_job "$ns" "$job" "$manifest"
+
+  # SECONDS, not a sleep counter: the kubectl calls in these loops cost more than the sleeps do.
+  deadline=$((SECONDS + 300))
+  # Capture the log as soon as the marker appears: once the Pod is gone, so is `kubectl logs`.
+  while true; do
+    # The newest Pod, not the first: if the Job retried before the marker appeared, the oldest one
+    # is dead and its log would never produce it.
+    pod=$(kubectl -n "$ns" get pod -l "job-name=$job" --sort-by=.metadata.creationTimestamp \
+      -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || true)
+    if [ -n "$pod" ] && kubectl -n "$ns" logs "$pod" 2>/dev/null \
+        > "$RUNNER_TEMP/$job-interrupted.log" \
+        && grep -qF "$marker" "$RUNNER_TEMP/$job-interrupted.log"; then
+      first="$pod"; break
+    fi
+    if job_condition_true "$ns" "$job" Complete; then
+      diag_and_die "$ns" "job/$job finished before it could be interrupted; raise the record count so the scan lasts longer"
+    fi
+    (( SECONDS < deadline )) || diag_and_die "$ns" "job/$job never logged '$marker'"
+    sleep 1
+  done
+
+  # A Job that had already retried has dead Pods too, so the replacement below is recognised by
+  # being absent from this snapshot rather than by not being the one killed.
+  before=$(kubectl -n "$ns" get pod -l "job-name=$job" -o jsonpath='{.items[*].metadata.name}')
+
+  # --force skips the graceful delete so the replacement starts promptly. Safe here because the
+  # checkpoint PVC is minikube's hostPath: a real CSI driver could leave the volume attached and
+  # block the next Pod from mounting it.
+  echo "interrupting job/$job by deleting pod/$first"
+  kubectl -n "$ns" delete "pod/$first" --grace-period=0 --force
+
+  # Wait for the replacement. A completed Job will never make one, which means the interruption
+  # missed -- fail rather than assert against a run that was never interrupted.
+  deadline=$((SECONDS + 300))
+  while [ -z "$resuming" ]; do
+    if job_condition_true "$ns" "$job" Complete; then
+      diag_and_die "$ns" "job/$job completed before the interruption landed; raise the record count so the scan lasts longer"
+    fi
+    names=$(kubectl -n "$ns" get pod -l "job-name=$job" -o jsonpath='{.items[*].metadata.name}')
+    for n in $names; do
+      case " $before " in *" $n "*) ;; *) resuming="$n"; break ;; esac
+    done
+    [ -n "$resuming" ] && break
+    (( SECONDS < deadline )) || diag_and_die "$ns" "job/$job did not start a Pod to resume with"
+    sleep 2
+  done
+  echo "job/$job resumed in pod/$resuming"
+
+  wait_for_job "$ns" "$job" "$timeout"
+  ok_pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
+    --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$ok_pod" ] || diag_and_die "$ns" "no succeeded Pod found for job/$job in $ns"
+  kubectl -n "$ns" logs "$ok_pod" > "$RUNNER_TEMP/$job-resumed.log"
 }
 
 # Extract a non-empty completion token from a finalize command's JSON output, or fail.
@@ -134,15 +245,38 @@ extract_completion_token() {
   printf '%s\n' "$token"
 }
 
+# Count the asset locks still held: finalize-auditor recovers every one it finds, so zero is what
+# says it left none behind. lock_type comes from AuditorInternalValues.
+# Usage: count_cosmos_held_locks <endpoint> <key> <database>
+count_cosmos_held_locks() {
+  count_cosmos_records_by_query "$1" "$2" "$3" asset_lock \
+    'SELECT VALUE COUNT(1) FROM c WHERE c.values.lock_type IN (2, 3)'
+}
+
+# Count the records left mid-transaction: such a record still needs its Coordinator record, so zero
+# means cleanup-coordinator orphaned none. tx_state and its values are ScalarDB internals.
+# Usage: count_cosmos_unsettled_records <endpoint> <key> <database> <container>
+count_cosmos_unsettled_records() {
+  count_cosmos_records_by_query "$1" "$2" "$3" "$4" \
+    'SELECT VALUE COUNT(1) FROM c WHERE c.values.tx_state IN (1, 2)'
+}
+
 # Count items in a container, authenticating with the given account endpoint and key.
-# Usage: count_cosmos_items <endpoint> <key> <database> <container>
-count_cosmos_items() {
-  local endpoint="$1" account_key="$2" database="$3" container="$4" output count
+# Usage: count_cosmos_records <endpoint> <key> <database> <container>
+count_cosmos_records() {
+  count_cosmos_records_by_query "$1" "$2" "$3" "$4" 'SELECT VALUE COUNT(1) FROM c'
+}
+
+# Run a query that returns a single number, and echo it.
+# Usage: count_cosmos_records_by_query <endpoint> <key> <database> <container> <query>
+count_cosmos_records_by_query() {
+  local endpoint="$1" account_key="$2" database="$3" container="$4" query="$5" output count
+  require_vars COSMOSDB_SHELL
   output=$("$COSMOSDB_SHELL" <<EOF
 connect "AccountEndpoint=${endpoint};AccountKey=${account_key};"
 cd ${database}
 cd ${container}
-query "SELECT * FROM c" | jq '.items | length'
+query "${query}" | jq '.items[0]'
 exit
 EOF
 )

--- a/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
+++ b/scalardl-cleanup/ci/e2e/cleanup-jobs.sh
@@ -7,8 +7,8 @@
 #
 # Required environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
-#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary (count_cosmos_records only, and it
-#                    checks for it itself)
+#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, needed only by the counting helpers,
+#                    which check for it themselves
 #   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed. It sets no shell
 # options of its own; the caller is expected to run under `set -euo pipefail`, which some of these
@@ -175,7 +175,7 @@ reset_checkpoint() {
 
 # Run a Job, kill the Pod once it logs the caller's marker, and let the Job's own backoffLimit start
 # the Pod that resumes: the checkpoint PVC outlives the Pod. Writes the killed Pod's log to
-# $RUNNER_TEMP/<job>-interrupted.log and the succeeding Pod's to <job>-resumed.log.
+# $RUNNER_TEMP/<job>-interrupted.log and the resuming Pod's to <job>-resumed.log.
 # Usage: interrupt_and_resume <namespace> <job> <manifest> <started-marker> [timeout]
 interrupt_and_resume() {
   local ns="$1" job="$2" manifest="$3" marker="$4" timeout="${5:-900}"
@@ -202,8 +202,7 @@ interrupt_and_resume() {
     sleep 1
   done
 
-  # A Job that had already retried has dead Pods too, so the replacement below is recognised by
-  # being absent from this snapshot rather than by not being the one killed.
+  # Snapshot the Pods that exist now: the one that resumes is the name that is not among them.
   before=$(kubectl -n "$ns" get pod -l "job-name=$job" -o jsonpath='{.items[*].metadata.name}')
 
   # --force skips the graceful delete so the replacement starts promptly. Safe here because the
@@ -221,6 +220,7 @@ interrupt_and_resume() {
     fi
     names=$(kubectl -n "$ns" get pod -l "job-name=$job" -o jsonpath='{.items[*].metadata.name}')
     for n in $names; do
+      # Take the first name missing from the snapshot.
       case " $before " in *" $n "*) ;; *) resuming="$n"; break ;; esac
     done
     [ -n "$resuming" ] && break
@@ -233,6 +233,7 @@ interrupt_and_resume() {
   ok_pod=$(kubectl -n "$ns" get pod -l "job-name=$job" \
     --field-selector=status.phase=Succeeded -o jsonpath='{.items[0].metadata.name}')
   [ -n "$ok_pod" ] || diag_and_die "$ns" "no succeeded Pod found for job/$job in $ns"
+  [ "$ok_pod" = "$resuming" ] || diag_and_die "$ns" "job/$job resumed in pod/$resuming but succeeded in pod/$ok_pod"
   kubectl -n "$ns" logs "$ok_pod" > "$RUNNER_TEMP/$job-resumed.log"
 }
 

--- a/scalardl-cleanup/ci/e2e/common.sh
+++ b/scalardl-cleanup/ci/e2e/common.sh
@@ -16,8 +16,8 @@ export AUDITOR_NS="auditor-e2e"
 export AUDITOR_TLS_SAN="auditor.e2e.scalar-labs.com"
 CERTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
 
-# require_vars VAR...
 # Abort unless every named environment variable is set and non-empty.
+# Usage: require_vars <var>...
 require_vars() {
   for v in "$@"; do
     if [[ -z "${!v:-}" ]]; then echo "ERROR: $v must be set" >&2; exit 1; fi
@@ -25,6 +25,7 @@ require_vars() {
 }
 
 # Dump everything useful about a namespace's workloads, then fail.
+# Usage: diag_and_die <namespace> <message>
 diag_and_die() {
   local ns="$1" msg="$2"
   echo "::error::${msg}"
@@ -39,20 +40,36 @@ diag_and_die() {
   exit 1
 }
 
-# Poll a Job for complete/failed (kubectl wait --for=complete hangs on failure),
-# printing diagnostics inline the moment it fails or times out.
-wait_for_job() {
-  local ns="$1" job="$2" timeout="${3:-300}" waited=0
+# Poll a Job until it reaches the awaited condition (kubectl wait --for=complete hangs on failure),
+# printing diagnostics inline the moment it reaches the other one or times out.
+# Usage: wait_for_job_condition <namespace> <job> <awaited: Complete|Failed> <timeout>
+wait_for_job_condition() {
+  local ns="$1" job="$2" awaited="$3" timeout="$4" waited=0 other
+  if [ "$awaited" = Complete ]; then other=Failed; else other=Complete; fi
   while true; do
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null | grep -q True; then
-      echo "job/$job complete"; return 0
+    if job_condition_true "$ns" "$job" "$awaited"; then
+      echo "job/$job reached $awaited"; return 0
     fi
-    if kubectl -n "$ns" get "job/$job" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null | grep -q True; then
-      diag_and_die "$ns" "job/$job failed"
+    if job_condition_true "$ns" "$job" "$other"; then
+      diag_and_die "$ns" "job/$job reached $other but $awaited was expected"
     fi
     if (( waited >= timeout )); then
-      diag_and_die "$ns" "job/$job did not complete within ${timeout}s"
+      diag_and_die "$ns" "job/$job reached neither $awaited nor $other within ${timeout}s"
     fi
     sleep 5; waited=$((waited + 5))
   done
 }
+
+# Usage: job_condition_true <namespace> <job> <condition>
+job_condition_true() {
+  kubectl -n "$1" get "job/$2" \
+    -o jsonpath="{.status.conditions[?(@.type==\"$3\")].status}" 2>/dev/null | grep -q True
+}
+
+# Wait for a Job to succeed.
+# Usage: wait_for_job <namespace> <job> [timeout]
+wait_for_job() { wait_for_job_condition "$1" "$2" Complete "${3:-300}"; }
+
+# Wait for a Job to fail.
+# Usage: wait_for_job_failure <namespace> <job> [timeout]
+wait_for_job_failure() { wait_for_job_condition "$1" "$2" Failed "${3:-300}"; }

--- a/scalardl-cleanup/ci/e2e/manage-cluster.sh
+++ b/scalardl-cleanup/ci/e2e/manage-cluster.sh
@@ -5,32 +5,34 @@
 # credentials, and a Cosmos account.
 #
 # Modes:
-#   deploy       load the ScalarDB schema, deploy Ledger + Auditor, wait until healthy
-#   stop-ledger  scale the Ledger to 0 and wait for its pod to be deleted
-#   upgrade      switch Ledger + Auditor to the SCALARDL_VERSION images, bring the Ledger
-#                back up (it was scaled to 0 to strand locks), and wait until both are healthy
-#   drop-schema  delete the ScalarDB schema (Cosmos cleanup)
-#   clean        delete the k8s namespaces
+#   deploy          load the ScalarDB schema, deploy Ledger + Auditor, wait until healthy
+#   stop-ledger     scale the Ledger to 0 and wait for its pod to be deleted
+#   change-version  switch Ledger + Auditor to the SCALARDL_VERSION images, bring the Ledger back
+#                   up (it may have been scaled to 0 to strand locks), and wait until both are
+#                   healthy. Works in both directions, so the fixture can roll back to the old one
+#   drop-schema     delete the ScalarDB schema (Cosmos cleanup)
+#   reset-schema    replace the schema with an empty one, and restart the servers so they see it
+#   clean           delete the k8s namespaces
 #
 # The cleanup tool is meant to reclaim garbage left behind by an older ScalarDL server while
 # coordinating with the upgraded server. The E2E therefore deploys an old version, creates the
-# garbage, then runs `upgrade` to the new version before running the tool:
-#   SCALARDL_VERSION=<old> ... ./manage-cluster.sh deploy    # create the garbage
-#   SCALARDL_VERSION=<new>     ./manage-cluster.sh upgrade   # roll servers to the new version
+# garbage, then runs `change-version` to the new version before running the tool:
+#   SCALARDL_VERSION=<old> ... ./manage-cluster.sh deploy          # create the garbage
+#   SCALARDL_VERSION=<new>     ./manage-cluster.sh change-version  # roll to the new version
 #
-# Required environment (deploy and drop-schema only):
-#   COSMOS_URI   Cosmos DB account URI
-#   COSMOS_KEY   Cosmos DB primary key
-#   CR_PAT       ghcr Personal Access Token with read:packages
-#   GHCR_USER    ghcr username that owns CR_PAT
+# Required environment:
+#   COSMOS_URI   Cosmos DB account URI                        (schema modes and deploy)
+#   COSMOS_KEY   Cosmos DB primary key                        (schema modes and deploy)
+#   CR_PAT       ghcr Personal Access Token with read:packages (deploy only: it creates the
+#   GHCR_USER    ghcr username that owns CR_PAT                 ghcr-secret the Jobs pull with)
 #
 # Optional (default shown):
 #   SCALARDL_VERSION=3.13.0   # image tag for ledger, auditor, and schema-loader
 #
 # Usage:
 #   COSMOS_URI=... COSMOS_KEY=... CR_PAT=... GHCR_USER=... ./manage-cluster.sh deploy
-#   SCALARDL_VERSION=<new> ./manage-cluster.sh upgrade
-#   ./manage-cluster.sh stop-ledger | drop-schema | clean
+#   SCALARDL_VERSION=<new> ./manage-cluster.sh change-version
+#   ./manage-cluster.sh stop-ledger | drop-schema | reset-schema | clean
 
 set -euo pipefail
 
@@ -51,12 +53,6 @@ export SL_IMAGE="ghcr.io/scalar-labs/scalardl-schema-loader:${SCALARDL_VERSION}"
 export SERVERS_HMAC_SECRET="e2e-servers-hmac-secret-disposable-0123456789"
 export HMAC_CIPHER_KEY="e2e-hmac-cipher-key-disposable-0123456789abcdef"
 
-# Schema-loader arguments. schema-loader.yaml is parametrized for both create (deploy)
-# and delete (drop-schema); these are the create defaults, overridden in drop-schema.
-export SL_JOB_SUFFIX=""
-export SL_LEDGER_ARGS='["--config", "/config/database.properties", "--coordinator"]'
-export SL_AUDITOR_ARGS='["--config", "/config/database.properties"]'
-
 # Give envsubst an explicit variable list so it substitutes ONLY these placeholders.
 # Without a list, envsubst expands EVERY $VAR in the manifests, which would wrongly
 # rewrite unrelated shell-style tokens (e.g. a literal $@ in a container command).
@@ -64,11 +60,14 @@ SUBST_VARS='${LEDGER_NS} ${AUDITOR_NS} ${LEDGER_IMAGE} ${AUDITOR_IMAGE} ${SL_IMA
 SUBST_VARS+='${COSMOS_URI} ${COSMOS_KEY} ${SERVERS_HMAC_SECRET} ${HMAC_CIPHER_KEY} '
 SUBST_VARS+='${SL_JOB_SUFFIX} ${SL_LEDGER_ARGS} ${SL_AUDITOR_ARGS}'
 
+# Substitute the placeholders above into one of the manifests next to this script.
+# Usage: render <manifest-filename>
 render() { envsubst "$SUBST_VARS" < "$HERE/$1"; }
 
 # Generate a disposable self-signed cert/key for the Auditor server TLS. Reused if it already exists,
 # so re-running deploy does not rotate the cert out from under a running Auditor pod (`clean` drops it
 # to force a fresh one). umask 077 keeps the private key private on a dev box.
+# Usage: gen_certs
 gen_certs() {
   mkdir -p "$CERTS_DIR"
   if [[ -s "$CERTS_DIR/auditor.crt" && -s "$CERTS_DIR/auditor-key.pem" ]]; then
@@ -83,6 +82,8 @@ gen_certs() {
       -addext "subjectAltName=DNS:${AUDITOR_TLS_SAN}" )
 }
 
+# Delete the namespaces, and the disposable TLS cert with them.
+# Usage: clean
 clean() {
   echo "Deleting namespaces ${LEDGER_NS} and ${AUDITOR_NS} ..."
   kubectl delete namespace "$LEDGER_NS" "$AUDITOR_NS" --ignore-not-found
@@ -91,6 +92,7 @@ clean() {
 }
 
 # Scale the Ledger to 0 and wait for its pod to disappear.
+# Usage: stop_ledger
 stop_ledger() {
   echo "==> scale down the Ledger"
   kubectl -n "$LEDGER_NS" scale deployment/scalardl-ledger --replicas=0
@@ -106,27 +108,36 @@ stop_ledger() {
 }
 
 # Roll the Ledger and Auditor to the SCALARDL_VERSION images (via `set image`, reusing the existing
-# config and pull secret) and wait until healthy. Also brings the Ledger back up, since it was
-# scaled to 0 earlier to strand locks.
-upgrade() {
-  echo "==> upgrade Ledger and Auditor images to ${LEDGER_IMAGE} / ${AUDITOR_IMAGE}"
+# config and pull secret) and wait until healthy. Also brings the Ledger back up, since populating
+# stranded locks scales it to 0.
+# Usage: change_version
+change_version() {
+  echo "==> set Ledger and Auditor images to ${LEDGER_IMAGE} / ${AUDITOR_IMAGE}"
   kubectl -n "$LEDGER_NS"  set image deployment/scalardl-ledger  scalardl-ledger="$LEDGER_IMAGE"
   kubectl -n "$AUDITOR_NS" set image deployment/scalardl-auditor scalardl-auditor="$AUDITOR_IMAGE"
   kubectl -n "$LEDGER_NS"  scale deployment/scalardl-ledger --replicas=1
 
+  wait_for_rollouts " after switching to $SCALARDL_VERSION"
+}
+
+# Wait for both Deployments to finish rolling, then health-check them: condition=available stays
+# true through a restart, and a tcpSocket probe cannot tell listening from serving.
+# Usage: wait_for_rollouts [message-suffix]
+wait_for_rollouts() {
+  local suffix="${1:-}"
   echo "==> wait for rollouts to finish"
   if ! kubectl -n "$LEDGER_NS" rollout status deployment/scalardl-ledger --timeout=300s; then
-    diag_and_die "$LEDGER_NS" "Ledger rollout to $LEDGER_IMAGE did not complete"
+    diag_and_die "$LEDGER_NS" "Ledger rollout did not complete${suffix}"
   fi
   if ! kubectl -n "$AUDITOR_NS" rollout status deployment/scalardl-auditor --timeout=300s; then
-    diag_and_die "$AUDITOR_NS" "Auditor rollout to $AUDITOR_IMAGE did not complete"
+    diag_and_die "$AUDITOR_NS" "Auditor rollout did not complete${suffix}"
   fi
-
-  grpc_health_checks " after upgrade to $SCALARDL_VERSION"
+  grpc_health_checks "$suffix"
 }
 
 # Health-check the Ledger (plaintext) and Auditor (TLS, verified against the SAN), aborting with
-# diagnostics on failure. $1 is an optional message suffix (e.g. " after upgrade to <version>").
+# diagnostics on failure. The suffix names what was rolled, e.g. " after switching to <version>".
+# Usage: grpc_health_checks [message-suffix]
 grpc_health_checks() {
   local suffix="${1:-}"
   echo "==> gRPC health checks"
@@ -142,6 +153,7 @@ grpc_health_checks() {
 }
 
 # Wait for a Deployment to become available, with inline diagnostics on timeout.
+# Usage: wait_for_deploy <namespace> <deployment> [timeout]
 wait_for_deploy() {
   local ns="$1" dep="$2" timeout="${3:-300}"
   if ! kubectl -n "$ns" wait --for=condition=available "deployment/$dep" --timeout="${timeout}s"; then
@@ -149,8 +161,51 @@ wait_for_deploy() {
   fi
 }
 
+# Run the schema-loader Jobs. Jobs are immutable, so leftovers go first and create and delete get
+# distinct name suffixes.
+# Usage: run_schema_loader <job-suffix> <ledger-args> <auditor-args>
+run_schema_loader() {
+  export SL_JOB_SUFFIX="$1" SL_LEDGER_ARGS="$2" SL_AUDITOR_ARGS="$3"
+  kubectl -n "$LEDGER_NS"  delete job "schema-loader-ledger$1"  --ignore-not-found
+  kubectl -n "$AUDITOR_NS" delete job "schema-loader-auditor$1" --ignore-not-found
+  render schema-loader.yaml | kubectl apply -f -
+  wait_for_job "$LEDGER_NS"  "schema-loader-ledger$1"  300
+  wait_for_job "$AUDITOR_NS" "schema-loader-auditor$1" 300
+}
+
+# Create the ScalarDB schema (ledger + coordinator, auditor).
+# Usage: load_schema
+load_schema() {
+  echo "==> load schemas (ledger + coordinator, auditor)"
+  run_schema_loader "" \
+    '["--config", "/config/database.properties", "--coordinator"]' \
+    '["--config", "/config/database.properties"]'
+}
+
+# Delete the ScalarDB schema.
+# Usage: drop_schema
+drop_schema() {
+  echo "==> delete ScalarDB schema (Cosmos cleanup)"
+  run_schema_loader "-delete" \
+    '["--config", "/config/database.properties", "-D", "--coordinator"]' \
+    '["--config", "/config/database.properties", "-D"]'
+}
+
+# Replace the schema with an empty one, then restart the servers so they drop their cached table
+# metadata. The health check that follows needs the Ledger at 1 replica.
+# Usage: reset_schema
+reset_schema() {
+  drop_schema
+  load_schema
+  echo "==> restart the servers so they read the recreated schema"
+  kubectl -n "$LEDGER_NS"  rollout restart deployment/scalardl-ledger
+  kubectl -n "$AUDITOR_NS" rollout restart deployment/scalardl-auditor
+  wait_for_rollouts " after the schema reset"
+}
+
 # Deploy schema + servers and block until both Deployments are available and pass a
 # gRPC health check. Leaves the servers running.
+# Usage: deploy_all
 deploy_all() {
   echo "==> create namespaces"
   kubectl create namespace "$LEDGER_NS" --dry-run=client -o yaml | kubectl apply -f -
@@ -166,13 +221,7 @@ deploy_all() {
       --dry-run=client -o yaml | kubectl apply -f -
   done
 
-  echo "==> load schemas (ledger + coordinator, auditor)"
-  # Jobs are immutable, so delete any leftovers first to keep re-runs idempotent.
-  kubectl -n "$LEDGER_NS"  delete job schema-loader-ledger  --ignore-not-found || true
-  kubectl -n "$AUDITOR_NS" delete job schema-loader-auditor --ignore-not-found || true
-  render schema-loader.yaml | kubectl apply -f -
-  wait_for_job "$LEDGER_NS"  schema-loader-ledger  300
-  wait_for_job "$AUDITOR_NS" schema-loader-auditor 300
+  load_schema
 
   echo "==> create Auditor TLS cert + secret"
   gen_certs
@@ -204,43 +253,37 @@ case "${1:-}" in
     echo
     echo "STOP-LEDGER OK: $LEDGER_NS/scalardl-ledger scaled to 0."
     ;;
-  upgrade)
+  change-version)
     if [[ -z "$SCALARDL_VERSION_EXPLICIT" ]]; then
-      echo "ERROR: SCALARDL_VERSION must be set explicitly for upgrade" >&2; exit 1
+      echo "ERROR: SCALARDL_VERSION must be set explicitly for change-version" >&2; exit 1
     fi
-    upgrade
+    change_version
     echo
-    echo "UPGRADE OK: $LEDGER_NS / $AUDITOR_NS rolled to ${SCALARDL_VERSION} and healthy."
+    echo "CHANGE-VERSION OK: $LEDGER_NS / $AUDITOR_NS rolled to ${SCALARDL_VERSION} and healthy."
     ;;
   drop-schema)
-    require_vars COSMOS_URI COSMOS_KEY CR_PAT GHCR_USER
+    require_vars COSMOS_URI COSMOS_KEY
     # If neither namespace exists, there is nothing to drop.
     if ! kubectl get namespace "$LEDGER_NS" >/dev/null 2>&1 \
         && ! kubectl get namespace "$AUDITOR_NS" >/dev/null 2>&1; then
       echo "Namespaces ${LEDGER_NS}/${AUDITOR_NS} not found; nothing to drop."
       exit 0
     fi
-    # Delete the ScalarDB schema so the shared Cosmos account stays clean between runs,
-    # by re-rendering schema-loader.yaml with delete args + a distinct name suffix (a
-    # completed create Job can't be re-applied under the same name).
-    echo "==> delete ScalarDB schema (Cosmos cleanup)"
-    export SL_JOB_SUFFIX="-delete"
-    export SL_LEDGER_ARGS='["--config", "/config/database.properties", "-D", "--coordinator"]'
-    export SL_AUDITOR_ARGS='["--config", "/config/database.properties", "-D"]'
-    # Delete leftovers first (Jobs are immutable) so drop-schema is re-runnable.
-    kubectl -n "$LEDGER_NS"  delete job schema-loader-ledger-delete  --ignore-not-found || true
-    kubectl -n "$AUDITOR_NS" delete job schema-loader-auditor-delete --ignore-not-found || true
-    render schema-loader.yaml | kubectl apply -f -
-    wait_for_job "$LEDGER_NS"  schema-loader-ledger-delete  300
-    wait_for_job "$AUDITOR_NS" schema-loader-auditor-delete 300
+    drop_schema
     echo
     echo "DROP-SCHEMA OK"
+    ;;
+  reset-schema)
+    require_vars COSMOS_URI COSMOS_KEY
+    reset_schema
+    echo
+    echo "RESET-SCHEMA OK: the schema is empty."
     ;;
   clean)
     clean
     ;;
   *)
-    echo "usage: manage-cluster.sh [deploy|stop-ledger|upgrade|drop-schema|clean]" >&2
+    echo "usage: manage-cluster.sh [deploy|stop-ledger|change-version|drop-schema|reset-schema|clean]" >&2
     exit 1
     ;;
 esac

--- a/scalardl-cleanup/ci/e2e/populate.sh
+++ b/scalardl-cleanup/ci/e2e/populate.sh
@@ -2,20 +2,28 @@
 #
 # Populate the E2E cluster with the garbage the cleanup commands are meant to reclaim.
 #
-# Modes, in the order .github/workflows/e2e.yaml runs them:
-#   commit-objects  register the client identity, then commit RECORD_COUNT objects
-#   strand-locks    scale the Ledger down and leave unreleased Auditor asset locks behind. It
-#                   leaves the Ledger at 0 replicas; `manage-cluster.sh upgrade` brings it back
-#   write-metadata  record what was populated, for the verification step to read back
+# Every mode records the ids it populated in $RUNNER_TEMP/populated-assets.json, which verify-assets
+# reads back.
+#
+# Modes:
+#   commit-objects             register the client identity, then commit RECORD_COUNT objects
+#   strand-locks               scale the Ledger down and leave unreleased Auditor asset locks
+#                              behind. It leaves the Ledger at 0 replicas; `manage-cluster.sh
+#                              change-version` brings it back
+#   commit-post-token-objects  commit RECORD_COUNT objects after the finalize commands took their
+#                              completion tokens
+#   verify-assets              run the object contracts against every asset the metadata lists,
+#                              given the count to expect
 #
 # Required environment:
 #   CLIENT        path to the ScalarDL HashStore CLI (the OLD version: the garbage is created by
 #                 the old client)
 #   RECORD_COUNT  records generated per category
-#   RUNNER_TEMP   scratch directory (metadata mode only)
+#   RUNNER_TEMP   scratch directory holding the populated-assets metadata
 #
 # Usage:
-#   ./populate.sh commit-objects | strand-locks | write-metadata
+#   ./populate.sh commit-objects | strand-locks | commit-post-token-objects
+#   ./populate.sh verify-assets <expected-id-count>
 
 set -euo pipefail
 
@@ -32,20 +40,35 @@ props="$HERE/client.properties"
 # Mirrors LockOrderRecoveryHandler.LOCK_VALID_PERIOD_MILLIS in scalardl-enterprise.
 LOCK_VALID_PERIOD_SECS=15
 
+# Record a category's ids in the metadata file, so a scenario can tell what was populated.
+# Usage: record_asset_ids <metadata-key> <id-prefix>
+record_asset_ids() {
+  local key="$1" prefix="$2" meta="$RUNNER_TEMP/populated-assets.json"
+  [ -f "$meta" ] || jq -n '{entityId: "e2e-client"}' > "$meta"
+  jq --argjson n "$RECORD_COUNT" --arg key "$key" --arg prefix "$prefix" \
+    '.[$key] = [range(0; $n) | "\($prefix)-\(.)"]' "$meta" > "$meta.new"
+  mv "$meta.new" "$meta"
+}
+
+# Commit RECORD_COUNT objects under the given id prefix.
+# Usage: commit_objects <id-prefix> <metadata-key>
 commit_objects() {
+  local prefix="$1" key="$2"
   pf_reset
   pf_start_all
-  # Register the client identity + the generic object contracts on both servers.
-  "$CLIENT" bootstrap --properties "$props"
-  # Commit RECORD_COUNT objects. In auditor mode each put-object (object.Put = get+put)
-  # produces asset / request_proof / coordinator.state / released asset_lock records.
+  "$CLIENT" bootstrap --properties "$props" # Idempotent
+  # In auditor mode each put-object (object.Put = get+put) produces asset / request_proof /
+  # coordinator.state / released asset_lock records.
   for i in $(seq 0 $((RECORD_COUNT - 1))); do
-    id="e2e-asset-$i"
+    id="$prefix-$i"
     hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
     "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"
   done
+  record_asset_ids "$key" "$prefix"
 }
 
+# Leave unreleased Auditor asset locks behind, past their valid period so they can be finalized.
+# Usage: strand_locks
 strand_locks() {
   pf_reset
   "$HERE/manage-cluster.sh" stop-ledger
@@ -69,35 +92,55 @@ strand_locks() {
   done
   echo "Waiting $((LOCK_VALID_PERIOD_SECS + 1))s for the held locks to pass the ${LOCK_VALID_PERIOD_SECS}s valid period ..."
   sleep $((LOCK_VALID_PERIOD_SECS + 1))
+  record_asset_ids strandedAssetIds e2e-stranded
 }
 
-# Record what was populated. The verify step reads this back (single source of truth for the
-# asset ids), and it is uploaded as an artifact for inspection. strandedReadAssetIds are the
-# committed ids that also received a stranded READ lock (== committedAssetIds here).
-write_metadata() {
-  jq -n --argjson n "$RECORD_COUNT" '{
-    entityId: "e2e-client",
-    committedAssetIds: [range(0; $n) | "e2e-asset-\(.)"],
-    strandedAssetIds: [range(0; $n) | "e2e-stranded-\(.)"],
-    strandedReadAssetIds: [range(0; $n) | "e2e-asset-\(.)"]
-  }' > "$RUNNER_TEMP/populated-assets.json"
+# Check that put-object, get-object and validate-ledger still work on every asset after cleanup.
+# put-object goes first because a stranded id has no committed version to read yet, and it reads the
+# asset before writing anyway.
+# Usage: verify_assets <expected-id-count>
+verify_assets() {
+  local expected="$1" meta="$RUNNER_TEMP/populated-assets.json" ids count id hash
+  pf_reset
+  pf_start_all
+  # Read the ids up front: a process substitution's exit status is invisible to `set -e`, so piping
+  # jq into the loop would run it zero times on a bad file and report success.
+  [ -s "$meta" ] || { echo "::error::$meta is missing or empty"; exit 1; }
+  ids=$(jq -r '[.[] | select(type == "array")] | flatten | .[]' "$meta") \
+    || { echo "::error::could not read the asset ids from $meta"; exit 1; }
+  count=$(printf '%s\n' "$ids" | grep -c . || true)
+  [ "$count" -eq "$expected" ] \
+    || { echo "::error::$meta lists $count asset ids (expected $expected)"; exit 1; }
+  while IFS= read -r id; do
+    hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
+    "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash" \
+      || { echo "::error::put-object on $id failed after cleanup"; exit 1; }
+    "$CLIENT" get-object --properties "$props" --object-id "$id" \
+      || { echo "::error::get-object on $id failed after cleanup"; exit 1; }
+    "$CLIENT" validate-ledger --properties "$props" --object-id "$id" \
+      || { echo "::error::validate-ledger on $id failed after cleanup"; exit 1; }
+  done <<< "$ids"
 }
 
 case "${1:-}" in
   commit-objects)
-    require_vars CLIENT RECORD_COUNT
-    commit_objects
+    require_vars CLIENT RECORD_COUNT RUNNER_TEMP
+    commit_objects e2e-asset committedAssetIds
     ;;
   strand-locks)
-    require_vars CLIENT RECORD_COUNT
+    require_vars CLIENT RECORD_COUNT RUNNER_TEMP
     strand_locks
     ;;
-  write-metadata)
-    require_vars RECORD_COUNT RUNNER_TEMP
-    write_metadata
+  commit-post-token-objects)
+    require_vars CLIENT RECORD_COUNT RUNNER_TEMP
+    commit_objects e2e-post-token postTokenAssetIds
+    ;;
+  verify-assets)
+    require_vars CLIENT RUNNER_TEMP
+    verify_assets "${2:?usage: populate.sh verify-assets <expected-id-count>}"
     ;;
   *)
-    echo "usage: populate.sh [commit-objects|strand-locks|write-metadata]" >&2
+    echo "usage: populate.sh [commit-objects|strand-locks|commit-post-token-objects|verify-assets]" >&2
     exit 1
     ;;
 esac

--- a/scalardl-cleanup/ci/e2e/port-forward.sh
+++ b/scalardl-cleanup/ci/e2e/port-forward.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Shared kubectl port-forward helpers for the E2E test cluster. Usage:
+# Shared kubectl port-forward helpers for the E2E test cluster. Source it:
 #
 #   source ci/e2e/port-forward.sh
 #   pf_reset       # kill leftovers from prior steps
@@ -15,16 +15,19 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 # TCP connect check via a bash builtin.
+# Usage: pf_check_tcp <local-port>
 pf_check_tcp() { timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/$1" 2>/dev/null; }
 
 # Kill any leftover kubectl port-forwards.
+# Usage: pf_reset
 pf_reset() {
   pkill -f 'kubectl.*port-forward.*(ledger|auditor)' 2>/dev/null || true
   sleep 2
 }
 
-# Start a background port-forward: pf_start <ns> <target> <local:remote>...
-# Logs to /tmp/pf-<first-local-port>.log so failure diagnostics can collect it.
+# Start a background port-forward. Logs to /tmp/pf-<first-local-port>.log so failure diagnostics
+# can collect it.
+# Usage: pf_start <namespace> <target> <local:remote>...
 pf_start() {
   local ns="$1" target="$2"
   shift 2
@@ -34,6 +37,7 @@ pf_start() {
 
 # Block until each given local port accepts a TCP connection (~30s each), else fail.
 # Returns non-zero on timeout so `set -e` callers abort.
+# Usage: pf_wait <local-port>...
 pf_wait() {
   local p i ok
   for p in "$@"; do

--- a/scalardl-cleanup/ci/e2e/run-cleanup.sh
+++ b/scalardl-cleanup/ci/e2e/run-cleanup.sh
@@ -5,9 +5,8 @@
 #
 #   source ci/e2e/run-cleanup.sh
 #
-# Expects in the environment:
+# Required environment:
 #   CLEANUP_VERSION  tag of the scalardl-cleanup image
-#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
 #   RUNNER_TEMP      scratch directory for the rendered manifests
 # and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
 #
@@ -18,8 +17,9 @@ E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$E2E_DIR/cleanup-jobs.sh"
 
 # Prepare what every step needs. Call once, before the first step.
+# Usage: init_cleanup_commands
 init_cleanup_commands() {
-  require_vars CLEANUP_VERSION COSMOSDB_SHELL RUNNER_TEMP
+  require_vars CLEANUP_VERSION RUNNER_TEMP
 
   # The Job manifests take the image tag as ${CLEANUP_VERSION}; the namespace is not in them and is
   # passed to kubectl instead. LEDGER_NS / AUDITOR_NS come from common.sh, via cleanup-jobs.sh.
@@ -30,6 +30,7 @@ init_cleanup_commands() {
 }
 
 # Run finalize-ledger (Ledger AD). Sets ledger_token.
+# Usage: run_finalize_ledger
 run_finalize_ledger() {
   local out
   setup_ledger_ad
@@ -42,6 +43,7 @@ run_finalize_ledger() {
 
 # Run finalize-auditor (Auditor AD). Sets auditor_token. Recovering a stranded lock can wait out the
 # lock's valid period, hence the longer timeout.
+# Usage: run_finalize_auditor
 run_finalize_auditor() {
   local out
   setup_auditor_ad

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -80,7 +80,7 @@ echo "request_proof rows: before=$rp_before_cleanup after=$rp_after_cleanup"
 
 # Nothing may still be pointing at the Coordinator records that were just deleted.
 for table in asset asset_metadata; do
-  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" ledger "$table")
+  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" scalar "$table")
   [ "$unsettled" -eq 0 ] \
     || { echo "::error::$table holds $unsettled records left mid-transaction"; exit 1; }
 done

--- a/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/happy-path.sh
@@ -3,88 +3,91 @@
 # Scenario: every command in run-cleanup.sh, in the documented apply order, against a cluster
 # holding both committed data and stranded Auditor locks.
 #
+# New traffic runs once the finalize commands have taken their completion tokens, because that is
+# the normal way to run the tool: the servers keep serving. The tokens fix the deletable-before
+# boundary, so the cleanup that follows has to leave that transaction state alone.
+#
 # Required environment:
-#   CLEANUP_VERSION  tag of the scalardl-cleanup image
-#   CLIENT           path to the ScalarDL HashStore CLI
-#   COSMOSDB_SHELL   path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
-#   RECORD_COUNT     records generated per category
-#   RUNNER_TEMP      scratch directory for the rendered manifests and the populated-assets
-#                    metadata
-# and a kubectl context with the ledger-e2e / auditor-e2e namespaces deployed.
+#   CLEANUP_VERSION           tag of the scalardl-cleanup image
+#   COSMOSDB_SHELL            path to the Azure Cosmos DB Shell binary, used to count rows in Cosmos
+#   RECORD_COUNT              records generated per category
+#   RUNNER_TEMP               scratch directory for the rendered manifests and the populated-assets
+#                             metadata
+#   SCALARDL_NEW_VERSION      the version the cleanup commands coordinate with
+# plus what setup-fixture.sh and populate.sh need, and a kubectl context with the namespaces
+# deployed.
 
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E="$HERE/.."
-source "$E2E/common.sh"
-source "$E2E/port-forward.sh"
 source "$E2E/run-cleanup.sh"
 
-# client.properties resolves the Auditor CA cert relative to scalardl-cleanup/.
-cd "$E2E/../.."
+require_vars RUNNER_TEMP RECORD_COUNT SCALARDL_NEW_VERSION
 
-props="$E2E/client.properties"
+echo "== Rebuild the fixture =="
+"$E2E/setup-fixture.sh"
 
-require_vars CLIENT RUNNER_TEMP RECORD_COUNT
+echo "== Upgrade the servers to $SCALARDL_NEW_VERSION =="
+SCALARDL_VERSION="$SCALARDL_NEW_VERSION" "$E2E/manage-cluster.sh" change-version
 
-echo "== Run the cleanup commands =="
+echo "== Run the finalize commands and check what they reclaimed =="
 
 init_cleanup_commands
 
 run_finalize_ledger
 
-rp_before=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+rp_before=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
 run_finalize_auditor
-rp_after=$(count_cosmos_items "$auditor_uri" "$auditor_key" auditor request_proof)
+rp_after=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
 echo "request_proof rows: before=$rp_before after=$rp_after"
 [ "$rp_after" -eq 0 ] || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
+held=$(count_cosmos_held_locks "$auditor_uri" "$auditor_key" auditor)
+[ "$held" -eq 0 ] || { echo "::error::finalize-auditor left $held asset locks held"; exit 1; }
 
-cs_before=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+echo "== Run new traffic now that both tokens are taken =="
+"$E2E/populate.sh" commit-post-token-objects
+
+rp_before_cleanup=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
+# The new traffic has to have written state, or the assertions below prove nothing.
+[ "$rp_before_cleanup" -gt 0 ] \
+  || { echo "::error::the new traffic left no request_proof rows"; exit 1; }
+
+echo "== Run cleanup-coordinator and check what it reclaimed =="
+
+cs_before=$(count_cosmos_records "$ledger_uri" "$ledger_key" coordinator state)
 run_cleanup_coordinator "$ledger_token" "$auditor_token"
 [ "$(printf '%s' "$cleanup_coordinator_output" | jq -r '.status_code')" = "OK" ] \
   || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
 
-cs_after=$(count_cosmos_items "$ledger_uri" "$ledger_key" coordinator state)
+cs_after=$(count_cosmos_records "$ledger_uri" "$ledger_key" coordinator state)
 # Only the RECORD_COUNT committed put transactions are settled before the deletable-before boundary,
-# so exactly those are removed. finalize-auditor's recovery aborts each stranded lock's nonce,
-# writing coordinator.state rows after the boundary, which survive and are not counted here.
+# so exactly those are removed. What survives is everything written after it: finalize-auditor
+# aborted each stranded lock's nonce (2 * RECORD_COUNT), and the new traffic committed RECORD_COUNT
+# more.
 echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
 [ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
   || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
-[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
-  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
+[ "$cs_after" -eq "$((3 * RECORD_COUNT))" ] \
+  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((3 * RECORD_COUNT)))"; exit 1; }
 
-echo "== Verify post-cleanup consistency =="
-pf_reset
-pf_start_all
-populated="$RUNNER_TEMP/populated-assets.json"
+# cleanup-coordinator deletes Coordinator state only; the request proofs the new traffic wrote are
+# not its to touch.
+rp_after_cleanup=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
+echo "request_proof rows: before=$rp_before_cleanup after=$rp_after_cleanup"
+[ "$rp_after_cleanup" -eq "$rp_before_cleanup" ] \
+  || { echo "::error::cleanup-coordinator changed request_proof from $rp_before_cleanup to $rp_after_cleanup"; exit 1; }
 
-# Read the ids up front rather than piping jq straight into the loop: a process substitution's exit
-# status is invisible to `set -e`, so a missing or malformed file would run the loop zero times and
-# report success. An empty list means the same thing, and is just as fatal.
-[ -s "$populated" ] || { echo "::error::$populated is missing or empty"; exit 1; }
-ids=$(jq -r '(.committedAssetIds + .strandedAssetIds)[]' "$populated") \
-  || { echo "::error::could not read the asset ids from $populated"; exit 1; }
-[ -n "$ids" ] || { echo "::error::$populated lists no asset ids to verify"; exit 1; }
-count=$(printf '%s\n' "$ids" | wc -l | tr -d ' ')
-# Both populated categories are RECORD_COUNT long, so a short list means a truncated file.
-[ "$count" -eq "$((2 * RECORD_COUNT))" ] \
-  || { echo "::error::$populated lists $count asset ids (expected $((2 * RECORD_COUNT)))"; exit 1; }
-echo "Verifying $count assets ..."
+# Nothing may still be pointing at the Coordinator records that were just deleted.
+for table in asset asset_metadata; do
+  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" ledger "$table")
+  [ "$unsettled" -eq 0 ] \
+    || { echo "::error::$table holds $unsettled records left mid-transaction"; exit 1; }
+done
+echo "no records left mid-transaction in asset or asset_metadata"
 
-# After cleanup, every asset must be fully usable again: writable, readable, and passing
-# ledger validation.
-while IFS= read -r id; do
-  hash=$(printf '%s' "$id" | sha256sum | cut -d' ' -f1)
-  if ! "$CLIENT" put-object --properties "$props" --object-id "$id" --hash "$hash"; then
-    echo "::error::put-object on $id failed after cleanup"; exit 1
-  fi
-  if ! "$CLIENT" get-object --properties "$props" --object-id "$id"; then
-    echo "::error::get-object on $id failed after cleanup"; exit 1
-  fi
-  if ! "$CLIENT" validate-ledger --properties "$props" --object-id "$id"; then
-    echo "::error::validate-ledger on $id failed after cleanup"; exit 1
-  fi
-done <<< "$ids"
+echo "== Verify the contracts still run =="
+# Three categories of RECORD_COUNT: the committed data, the stranded ids, and the new traffic.
+"$E2E/populate.sh" verify-assets "$((3 * RECORD_COUNT))"
 
-echo "Post-cleanup consistency verified."
+echo "Every command reclaimed what it should and spared what the tokens put out of reach."

--- a/scalardl-cleanup/ci/e2e/scenarios/interrupt-resume.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/interrupt-resume.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Scenario: each cleanup command interrupted once and left to resume from the same checkpoint. What
+# it reclaims, and the completion token it emits, must come out the same as an uninterrupted run.
+#
+# The Job's own backoffLimit does the resuming: deleting the Pod leaves the checkpoint PVC behind,
+# so the replacement picks the run up. For the finalize commands the proof is the start timestamp --
+# their completion token is derived from it, so an identical timestamp means an identical token.
+#
+# Catching a scan mid-flight needs it to last long enough, so this scenario rebuilds the fixture
+# with more records than the others.
+#
+# Required environment:
+#   CLEANUP_VERSION           tag of the scalardl-cleanup image
+#   COSMOSDB_SHELL            path to the Azure Cosmos DB Shell binary
+#   RECORD_COUNT              records per category. e2e.yaml overrides the other scenarios' value
+#                             for this step, because the scan has to walk enough rows to still be
+#                             running when the Pod is deleted
+#   RUNNER_TEMP               scratch directory for the rendered manifests and the Job logs
+#   SCALARDL_NEW_VERSION      the version the cleanup commands coordinate with
+# plus what setup-fixture.sh and populate.sh need, and a kubectl context with the namespaces
+# deployed.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E="$HERE/.."
+source "$E2E/run-cleanup.sh"
+
+require_vars RUNNER_TEMP RECORD_COUNT SCALARDL_NEW_VERSION
+
+# The line the scanner writes once it has the partition list and is about to read rows. Interrupting
+# on it, rather than on the "starting a new run" line that precedes any scan state, is what makes
+# the replacement Pod resume a scan instead of beginning one.
+SCAN_STARTED='Cosmos DB physical partitions:'
+# What a Pod logs when it picks up scan state the interrupted run left behind: either it reloaded a
+# table's partition list, or it skipped a table that run had already finished. Which of the two
+# appears depends on how far the interrupted Pod got, and finalize-ledger sweeps several tables.
+SCAN_RESUMED='Loaded [0-9]+ persisted FeedRanges|Skipping already'
+
+# The line each command writes when it begins a run of its own, which is how the assertions tell a
+# resumption from a fresh start. Only the finalize commands append the run's start timestamp.
+FINALIZE_STARTED='Starting a new run at'
+CLEANUP_STARTED='Starting a new run.'
+
+# The resuming Pod must pick the interrupted run up rather than begin its own.
+# Usage: assert_resumed <job> <started-marker>
+assert_resumed() {
+  local job="$1" marker="$2" log
+  log="$RUNNER_TEMP/$job-resumed.log"
+  grep -q 'resuming the previous run' "$log" \
+    || { echo "::error::$job did not resume the interrupted run"; exit 1; }
+  if grep -qF "$marker" "$log"; then
+    echo "::error::$job started a new run instead of resuming the interrupted one"; exit 1
+  fi
+  # The checkpoint carries the scan's own state too, not just the run's boundary.
+  grep -qE "$SCAN_RESUMED" "$log" \
+    || { echo "::error::$job kept no scan state from the interrupted run"; exit 1; }
+  # How far the resumed run got, for the log only: the tool logs nothing that would show a mid-page
+  # resume from a continuation token, so there is nothing to assert on.
+  grep -o 'Scan complete for [^ ]* [0-9]* records' "$log" || true
+}
+
+# The finalize commands also log which run they started and which they resumed, so for them the
+# timestamps must match -- and the completion token is derived from that timestamp.
+# Usage: assert_resumed_same_run <job>
+assert_resumed_same_run() {
+  local job="$1" started resumed
+  assert_resumed "$job" "$FINALIZE_STARTED"
+  # `|| true` keeps a no-match (grep exit 1, fatal under `set -o pipefail`) from aborting before the
+  # empty-check below can report which log line was missing.
+  started=$(grep -o "$FINALIZE_STARTED [^ ]*" "$RUNNER_TEMP/$job-interrupted.log" \
+    | tail -n1 | sed 's/.*at //; s/\.$//' || true)
+  [ -n "$started" ] || { echo "::error::$job did not log the run it started"; exit 1; }
+  resumed=$(grep -o 'resuming the previous run started at [^ ]*' "$RUNNER_TEMP/$job-resumed.log" \
+    | tail -n1 | sed 's/.*at //; s/\.$//' || true)
+  # finalize-auditor runs two orchestrators, and assert_resumed above is satisfied by either of them
+  # resuming. Only the first one logs a timestamp, so an empty value here means it did not resume.
+  [ -n "$resumed" ] || { echo "::error::$job did not resume the run it had started"; exit 1; }
+  [ "$started" = "$resumed" ] \
+    || { echo "::error::$job resumed a run started at $resumed (expected $started)"; exit 1; }
+  echo "$job resumed the run started at $started"
+}
+
+echo "== Rebuild the fixture with $RECORD_COUNT records per category =="
+"$E2E/setup-fixture.sh"
+
+echo "== Upgrade the servers to $SCALARDL_NEW_VERSION =="
+SCALARDL_VERSION="$SCALARDL_NEW_VERSION" "$E2E/manage-cluster.sh" change-version
+
+echo "== Run the finalize commands, interrupting each one =="
+
+# One row per query and a single worker: the scan then lasts long enough to interrupt, and it
+# checkpoints as often as it can. E2E-only -- the shipped manifests keep the defaults.
+extra_cleanup_properties='scalar.dl.tools.scan.cosmos.page_size=1
+scalar.dl.tools.scan.cosmos.max_threads=1'
+
+init_cleanup_commands
+
+setup_ledger_ad
+interrupt_and_resume "$LEDGER_NS" scalardl-finalize-ledger \
+  "$work/ledger-ad/finalize-ledger.yaml" "$SCAN_STARTED"
+assert_resumed_same_run scalardl-finalize-ledger
+ledger_out=$(read_job_output_json "$LEDGER_NS" scalardl-finalize-ledger)
+ledger_token=$(extract_completion_token finalize-ledger "$ledger_out")
+
+rp_before=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
+setup_auditor_ad
+interrupt_and_resume "$AUDITOR_NS" scalardl-finalize-auditor \
+  "$work/auditor-ad/finalize-auditor.yaml" "$SCAN_STARTED"
+assert_resumed_same_run scalardl-finalize-auditor
+auditor_out=$(read_job_output_json "$AUDITOR_NS" scalardl-finalize-auditor)
+auditor_token=$(extract_completion_token finalize-auditor "$auditor_out")
+# Known gap: finalize-auditor runs the lock sweep and then the request_proof cleanup, and the
+# interruption always lands in the first. The second therefore runs start to finish inside the
+# resumed Pod, so its own checkpoint and resume path are not covered here.
+rp_after=$(count_cosmos_records "$auditor_uri" "$auditor_key" auditor request_proof)
+echo "request_proof rows: before=$rp_before after=$rp_after"
+[ "$rp_after" -eq 0 ] \
+  || { echo "::error::finalize-auditor left $rp_after request_proof rows (expected 0)"; exit 1; }
+held=$(count_cosmos_held_locks "$auditor_uri" "$auditor_key" auditor)
+[ "$held" -eq 0 ] || { echo "::error::finalize-auditor left $held asset locks held"; exit 1; }
+
+echo "== Run cleanup-coordinator, interrupting it =="
+
+cs_before=$(count_cosmos_records "$ledger_uri" "$ledger_key" coordinator state)
+export LEDGER_TOKEN="$ledger_token" AUDITOR_TOKEN="$auditor_token"
+interrupt_and_resume "$LEDGER_NS" scalardl-cleanup-coordinator \
+  "$work/ledger-ad/cleanup-coordinator.yaml" "$SCAN_STARTED"
+assert_resumed scalardl-cleanup-coordinator "$CLEANUP_STARTED"
+# The resumed Pod gets the same manifest, so the same tokens: what shows the boundary came from the
+# checkpoint rather than from recomputing it is that the command says it ignored them.
+grep -q 'the specified completion tokens are ignored' \
+  "$RUNNER_TEMP/scalardl-cleanup-coordinator-resumed.log" \
+  || { echo "::error::cleanup-coordinator did not report ignoring the tokens it was given"; exit 1; }
+coord_out=$(read_job_output_json "$LEDGER_NS" scalardl-cleanup-coordinator)
+[ "$(printf '%s' "$coord_out" | jq -r '.status_code')" = "OK" ] \
+  || { echo "::error::cleanup-coordinator did not report OK"; exit 1; }
+
+# What an uninterrupted run of this fixture reclaims: exactly the committed transactions settled
+# before the boundary are removed, and the rows finalize-auditor wrote while aborting the stranded
+# nonces survive. This fixture sees no traffic after the tokens, so nothing else is in play.
+cs_after=$(count_cosmos_records "$ledger_uri" "$ledger_key" coordinator state)
+echo "coordinator.state rows: before=$cs_before after=$cs_after (expected deleted=$RECORD_COUNT)"
+[ "$((cs_before - cs_after))" -eq "$RECORD_COUNT" ] \
+  || { echo "::error::cleanup-coordinator deleted $((cs_before - cs_after)) coordinator.state rows (expected $RECORD_COUNT)"; exit 1; }
+[ "$cs_after" -eq "$((2 * RECORD_COUNT))" ] \
+  || { echo "::error::coordinator.state has $cs_after rows after cleanup (expected $((2 * RECORD_COUNT)))"; exit 1; }
+
+# Nothing may still be pointing at the Coordinator records that were just deleted.
+for table in asset asset_metadata; do
+  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" ledger "$table")
+  [ "$unsettled" -eq 0 ] \
+    || { echo "::error::$table holds $unsettled records left mid-transaction"; exit 1; }
+done
+echo "no records left mid-transaction in asset or asset_metadata"
+
+echo "== Verify the contracts still run =="
+# Interrupting is where a double delete or a skipped record would show up, so exercise the assets
+# here too. Two categories of RECORD_COUNT: this fixture sees no traffic after the tokens.
+"$E2E/populate.sh" verify-assets "$((2 * RECORD_COUNT))"
+
+echo "Every command resumed its interrupted run and reclaimed what an uninterrupted run would."

--- a/scalardl-cleanup/ci/e2e/scenarios/interrupt-resume.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/interrupt-resume.sh
@@ -149,7 +149,7 @@ echo "coordinator.state rows: before=$cs_before after=$cs_after (expected delete
 
 # Nothing may still be pointing at the Coordinator records that were just deleted.
 for table in asset asset_metadata; do
-  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" ledger "$table")
+  unsettled=$(count_cosmos_unsettled_records "$ledger_uri" "$ledger_key" scalar "$table")
   [ "$unsettled" -eq 0 ] \
     || { echo "::error::$table holds $unsettled records left mid-transaction"; exit 1; }
 done

--- a/scalardl-cleanup/ci/e2e/scenarios/old-auditor.sh
+++ b/scalardl-cleanup/ci/e2e/scenarios/old-auditor.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Scenario: finalize-auditor against an Auditor that predates the privileged RecoverAssetLock RPC.
+# It must fail with DL-TOOLS-1014, which names the missing RPC and tells the operator to upgrade.
+#
+# Required environment:
+#   CLEANUP_VERSION  tag of the scalardl-cleanup image
+#   RUNNER_TEMP      scratch directory for the rendered manifests
+# plus what setup-fixture.sh needs, and a kubectl context with the namespaces deployed.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E="$HERE/.."
+source "$E2E/run-cleanup.sh"
+
+echo "== Rebuild the fixture =="
+"$E2E/setup-fixture.sh"
+
+echo "== Run finalize-auditor against the old-version Auditor =="
+
+init_cleanup_commands
+setup_auditor_ad
+out=$(run_job_expect_failure "$AUDITOR_NS" scalardl-finalize-auditor \
+  "$work/auditor-ad/finalize-auditor.yaml")
+echo "finalize-auditor output: $out"
+
+# USER_ERROR rather than INTERNAL_ERROR: an out-of-date server is the operator's to fix.
+status=$(printf '%s' "$out" | jq -r '.status_code')
+[ "$status" = "USER_ERROR" ] \
+  || { echo "::error::finalize-auditor reported status_code=$status (expected USER_ERROR)"; exit 1; }
+
+message=$(printf '%s' "$out" | jq -r '.error_message')
+case "$message" in
+  DL-TOOLS-1014:*) ;;
+  *) echo "::error::finalize-auditor reported '$message' (expected DL-TOOLS-1014)"; exit 1 ;;
+esac
+
+# The failed run persisted its start timestamp and its scan progress. Every scenario rebuilds the
+# fixture and would clear it anyway; dropping it here keeps this one from leaving state behind.
+reset_checkpoint "$AUDITOR_NS"
+
+echo "finalize-auditor failed as expected: $message"

--- a/scalardl-cleanup/ci/e2e/setup-fixture.sh
+++ b/scalardl-cleanup/ci/e2e/setup-fixture.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Rebuild the fixture a scenario starts from: an empty schema, empty checkpoint volumes, and the
+# garbage an OLD ScalarDL server leaves behind. It leaves the servers on the OLD version, so a
+# scenario that wants them upgraded runs `manage-cluster.sh change-version` itself.
+#
+# Required environment:
+#   SCALARDL_OLD_VERSION                 the version that leaves the garbage behind
+#   COSMOS_URI / COSMOS_KEY              the schema-loader Jobs are rendered with these
+#   CLIENT / RECORD_COUNT / RUNNER_TEMP  populate.sh needs these
+#
+# Usage:
+#   ./setup-fixture.sh
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# LEDGER_NS / AUDITOR_NS and require_vars come from common.sh; reset_checkpoint from cleanup-jobs.sh.
+source "$HERE/cleanup-jobs.sh"
+
+# Check everything up front: the checkpoint reset below destroys state, so a missing variable should
+# stop us before that rather than halfway through.
+require_vars SCALARDL_OLD_VERSION COSMOS_URI COSMOS_KEY CLIENT RECORD_COUNT RUNNER_TEMP
+
+# The metadata describes what this fixture populated, so the previous one's must not survive it.
+rm -f "$RUNNER_TEMP/populated-assets.json"
+
+echo "==> reset the checkpoint volumes"
+reset_checkpoint "$LEDGER_NS"
+reset_checkpoint "$AUDITOR_NS"
+
+echo "==> put the servers on ${SCALARDL_OLD_VERSION}"
+SCALARDL_VERSION="$SCALARDL_OLD_VERSION" "$HERE/manage-cluster.sh" change-version
+
+echo "==> reset the schema"
+SCALARDL_VERSION="$SCALARDL_OLD_VERSION" "$HERE/manage-cluster.sh" reset-schema
+
+echo "==> populate data"
+"$HERE/populate.sh" commit-objects
+"$HERE/populate.sh" strand-locks
+
+echo "SETUP-FIXTURE OK: the garbage is in place and the servers are on ${SCALARDL_OLD_VERSION}."


### PR DESCRIPTION
## Description

This PR takes the E2E test to the three cases the review of #55 asked for: a command interrupted midway, traffic arriving after the completion tokens are taken, and `finalize-auditor` run against a server too old for the RPC it needs.

Please focus your review on the added scenario sections.

## Related issues and/or PRs

- #55 
- #79 

## Changes made

- Add a scenario that runs `finalize-auditor` against an Auditor without `RecoverAssetLock` and asserts it fails as a user error naming the missing RPC.
- Add a scenario that interrupts each command mid-scan and asserts the replacement Pod resumes the same run rather than starting a new one.
- Run new traffic in the happy path once both tokens are taken, and assert the cleanup leaves that transaction state alone.
- Give every scenario its own fixture rebuild, so none of them depends on the order they run in.
- Assert the invariants directly in Cosmos: nothing left mid-transaction, no asset locks still held.
- Settle the comment conventions across `ci/e2e`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.


## Additional notes (optional)

N/A

## Release notes

N/A